### PR TITLE
Update Viewer models instead of reinitializing Viewers

### DIFF
--- a/viewer3d/__init__.py
+++ b/viewer3d/__init__.py
@@ -134,7 +134,7 @@ from viewer3d.modules import (
     setZoom,
     setZoomTo,
 )
-import viewer3d.presets as presets
+import viewer3d.presets
 
 __all__ = [
     "expand_notebook",

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -1,4 +1,5 @@
 import attr
+import collections
 import math
 import logging
 import sys
@@ -12,18 +13,60 @@ from IPython.display import clear_output
 from pyrosetta import Pose
 from pyrosetta.distributed.packed_pose.core import PackedPose
 from pyrosetta.rosetta.core.pose import append_pose_to_pose
-from typing import Generic, List, Optional, Tuple, TypeVar, Union
+from typing import Generic, Iterable, List, Optional, Tuple, TypeVar, Union
 
-from viewer3d.config import _import_backend
-from viewer3d.converters import _to_widgets
+from viewer3d.config import _import_backend, BACKENDS
+from viewer3d.converters import _to_float, _to_widgets
 from viewer3d.exceptions import ViewerImportError
+from viewer3d.modules import ModuleBase
+from viewer3d.validators import _validate_int_float, _validate_window_size
 
 
 _logger = logging.getLogger("viewer3d.base")
 
 
-@attr.s(kw_only=False, slots=False, frozen=False)
-class WidgetsBase:
+@attr.s(kw_only=False, slots=False)
+class Base3D:
+    poses = attr.ib(type=Iterable[Pose], default=None)
+    pdbstrings = attr.ib(type=Iterable[str], default=None)
+    n_decoys = attr.ib(type=int, default=None)
+    window_size = attr.ib(
+        type=Tuple[Union[int, float], Union[int, float]],
+        default=None,
+        validator=[
+            attr.validators.deep_iterable(
+                member_validator=attr.validators.instance_of((int, float)),
+                iterable_validator=attr.validators.instance_of(
+                    collections.abc.Iterable
+                ),
+            ),
+            _validate_window_size,
+        ],
+        converter=attr.converters.default_if_none(default=(1200, 800)),
+    )
+    modules = attr.ib(
+        type=list,
+        default=None,
+        validator=attr.validators.deep_iterable(
+            member_validator=attr.validators.instance_of(ModuleBase),
+            iterable_validator=attr.validators.instance_of(list),
+        ),
+        converter=attr.converters.default_if_none(default=[]),
+    )
+    delay = attr.ib(
+        type=float,
+        default=None,
+        validator=_validate_int_float,
+        converter=attr.converters.pipe(
+            attr.converters.default_if_none(0.25), _to_float
+        ),
+    )
+    continuous_update = attr.ib(
+        type=bool,
+        default=None,
+        validator=attr.validators.instance_of(bool),
+        converter=attr.converters.default_if_none(default=False),
+    )
     widgets = attr.ib(
         type=Optional[List[Widget]],
         default=None,
@@ -35,39 +78,12 @@ class WidgetsBase:
         ),
         converter=_to_widgets,
     )
-
-    def set_widgets(self, obj):
-        self.widgets = _to_widgets(obj)
-
-    def get_widgets(self):
-        _widgets = self.widgets.copy()
-        if self.n_decoys > 1:
-            _widgets.insert(0, self.decoy_widget)
-        return _widgets
-
-
-@attr.s(kw_only=False, slots=False, frozen=False)
-class ViewerBase(WidgetsBase):
-    poses = attr.ib(type=Pose, default=None)
-    pdbstrings = attr.ib(type=PackedPose, default=None)
-    n_decoys = attr.ib(type=int, default=None)
-    window_size = attr.ib(type=Tuple[Union[int, float]], default=None)
-    modules = attr.ib(type=list, default=None)
-    delay = attr.ib(type=float, default=None)
-    continuous_update = attr.ib(type=bool, default=None)
-    backend = attr.ib(type=str, default=None)
-
-    def __attrs_post_init__(self):
-        self.setup()
-        self.decoy_widget = interactive(
-            self.update_decoy,
-            index=IntSlider(
-                min=0,
-                max=self.n_decoys - 1,
-                description="Decoys",
-                continuous_update=self.continuous_update,
-            ),
-        )
+    backend = attr.ib(
+        type=str,
+        default=None,
+        validator=[attr.validators.instance_of(str), attr.validators.in_(BACKENDS)],
+        converter=attr.converters.default_if_none(default=BACKENDS[0]),
+    )
 
     def _maybe_import_backend(self):
         if self.backend not in sys.modules:
@@ -77,42 +93,6 @@ class ViewerBase(WidgetsBase):
                 raise ViewerImportError(self.backend)
 
         return sys.modules[self.backend]
-
-    def add_pose(self, pose=None, new_chain=False):
-        assert isinstance(
-            pose, Pose
-        ), f"Object must be of type `Pose`. Received: {type(pose)}"
-        kwargs = self.decoy_widget.kwargs
-        index = kwargs["index"] if kwargs else 0
-        self.poses[index] = self.poses[index].clone()
-        append_pose_to_pose(self.poses[index], pose, new_chain=new_chain)
-        self.update_viewer(self.poses[index])
-
-    def apply_modules(self, _pose=None, _pdbstring=None):
-        for _module in self.modules:
-            func = getattr(_module, f"apply_{self.backend}")
-            self.viewer = func(
-                self.viewer,
-                _pose,
-                _pdbstring,
-            )
-
-    def update_objects(self, _pose=None, _pdbstring=None):
-        """Setup Viewer in Jupyter notebook."""
-        self.remove_objects()
-        self.add_objects(_pose=_pose, _pdbstring=_pdbstring)
-        self.apply_modules(_pose=_pose, _pdbstring=_pdbstring)
-
-    def update_decoy(self, index=0):
-        time.sleep(self.delay)
-        self.update_viewer(self.poses[index], self.pdbstrings[index])
-
-    def show(self):
-        """Display Viewer in Jupyter notebook."""
-        self._toggle_scrolling()
-        self._toggle_window(self.window_size)
-        display(*self.get_widgets())
-        self.show_viewer()
 
     def __add__(self, other):
         self.modules += [other]
@@ -185,6 +165,75 @@ class ViewerBase(WidgetsBase):
         self.modules = None
         self.delay = None
         self.continuous_update = None
+
+
+@attr.s(kw_only=False, slots=False)
+class WidgetsBase:
+    def set_widgets(self, obj):
+        self.widgets = _to_widgets(obj)
+
+    def get_widgets(self):
+        _widgets = self.widgets.copy()
+        if self.n_decoys > 1:
+            _widgets.insert(0, self.decoy_widget)
+        return _widgets
+
+    def get_decoy_widget(self):
+        return interactive(
+            self.update_decoy,
+            index=IntSlider(
+                min=0,
+                max=self.n_decoys - 1,
+                description="Decoys",
+                continuous_update=self.continuous_update,
+            ),
+        )
+
+
+@attr.s(kw_only=False, slots=False)
+class ViewerBase(Base3D, WidgetsBase):
+    decoy_widget = attr.ib(
+        default=attr.Factory(WidgetsBase.get_decoy_widget, takes_self=True),
+    )
+
+    def __attrs_post_init__(self):
+        self.setup()
+
+    def add_pose(self, pose=None, new_chain=False):
+        assert isinstance(
+            pose, Pose
+        ), f"Object must be of type `Pose`. Received: {type(pose)}"
+        kwargs = self.decoy_widget.kwargs
+        index = kwargs["index"] if kwargs else 0
+        self.poses[index] = self.poses[index].clone()
+        append_pose_to_pose(self.poses[index], pose, new_chain=new_chain)
+        self.update_viewer(self.poses[index])
+
+    def apply_modules(self, _pose=None, _pdbstring=None):
+        for _module in self.modules:
+            func = getattr(_module, f"apply_{self.backend}")
+            self.viewer = func(
+                self.viewer,
+                _pose,
+                _pdbstring,
+            )
+
+    def update_objects(self, _pose=None, _pdbstring=None):
+        """Setup Viewer in Jupyter notebook."""
+        self.remove_objects()
+        self.add_objects(_pose=_pose, _pdbstring=_pdbstring)
+        self.apply_modules(_pose=_pose, _pdbstring=_pdbstring)
+
+    def update_decoy(self, index=0):
+        time.sleep(self.delay)
+        self.update_viewer(self.poses[index], self.pdbstrings[index])
+
+    def show(self):
+        """Display Viewer in Jupyter notebook."""
+        self._toggle_scrolling()
+        self._toggle_window(self.window_size)
+        display(*self.get_widgets())
+        self.show_viewer()
 
 
 def expand_notebook():

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -14,7 +14,6 @@ from pyrosetta.distributed.packed_pose.core import PackedPose
 from pyrosetta.rosetta.core.pose import append_pose_to_pose
 from typing import Generic, List, Optional, Tuple, TypeVar, Union
 
-from viewer3d.config import BACKENDS
 from viewer3d.config import _import_backend
 from viewer3d.converters import _to_widgets
 from viewer3d.exceptions import ViewerImportError

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -2,6 +2,7 @@ import attr
 import math
 import logging
 import sys
+import time
 
 from ipywidgets import interact, IntSlider
 
@@ -33,8 +34,9 @@ class ViewerBase:
 
         return sys.modules[self.backend]
 
-    def view(self, i=0):
-        self.update(self.poses[i], self.pdbstrings[i])
+    def update_decoy(self, i=0):
+        time.sleep(self.delay)
+        self.update_viewer(self.poses[i], self.pdbstrings[i])
 
     def setup(self):
         if self.n_decoys > 1:
@@ -44,9 +46,9 @@ class ViewerBase:
                 description="Decoys",
                 continuous_update=self.continuous_update,
             )
-            interact(self.view, i=s_widget)
+            interact(self.update_decoy, i=s_widget)
         else:
-            self.view()
+            self.update_decoy()
 
     def __add__(self, other):
         self.modules += [other]

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -34,11 +34,11 @@ class ViewerBase:
 
         return sys.modules[self.backend]
 
-    def update_decoy(self, i=0):
+    def _update_decoy(self, i=0):
         time.sleep(self.delay)
         self.update_viewer(self.poses[i], self.pdbstrings[i])
 
-    def setup(self):
+    def setup_widgets(self):
         if self.n_decoys > 1:
             s_widget = IntSlider(
                 min=0,
@@ -46,9 +46,14 @@ class ViewerBase:
                 description="Decoys",
                 continuous_update=self.continuous_update,
             )
-            interact(self.update_decoy, i=s_widget)
+            interact(self._update_decoy, i=s_widget)
         else:
-            self.update_decoy()
+            self._update_decoy()
+
+    def show(self):
+        """Display Viewer in Jupyter notebook."""
+        self.setup_widgets()
+        self.show_viewer()
 
     def __add__(self, other):
         self.modules += [other]

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -24,11 +24,11 @@ _logger = logging.getLogger("viewer3d.base")
 
 @attr.s(kw_only=False, slots=False, frozen=False)
 class ViewerBase:
-    # widgets = attr.ib(
-    #     type=Optional[Widget],
-    #     default=None,
-    #     validator=attr.validators.instance_of((type(None), Widget)),
-    # )
+    widget = attr.ib(
+        type=Optional[Widget],
+        default=None,
+        validator=attr.validators.instance_of((type(None), Widget)),
+    )
 
     def __attrs_pre_init__(self):
         self._toggle_scrolling()
@@ -47,8 +47,8 @@ class ViewerBase:
         self.update_viewer(self.poses[i], self.pdbstrings[i])
 
     def setup_widgets(self):
-        if self.widgets is not None:
-            display(self.widgets)
+        if self.widget is not None:
+            display(self.widget)
         else:
             if self.n_decoys > 1:
                 s_widget = IntSlider(

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -34,12 +34,9 @@ class ViewerBase:
         return sys.modules[self.backend]
 
     def view(self, i=0):
-        _pose = self.poses[i]
-        _pdbstring = self.pdbstrings[i]
+        self.update(self.poses[i], self.pdbstrings[i])
 
-        return self.update_viewer(_pose, _pdbstring)
-
-    def get_decoy_widget(self):
+    def setup(self):
         if self.n_decoys > 1:
             s_widget = IntSlider(
                 min=0,
@@ -47,11 +44,9 @@ class ViewerBase:
                 description="Decoys",
                 continuous_update=self.continuous_update,
             )
-            widget = interact(self.view, i=s_widget)
+            interact(self.view, i=s_widget)
         else:
-            widget = self.view()
-
-        return widget
+            self.view()
 
     def __add__(self, other):
         self.modules += [other]

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -3,6 +3,8 @@ import math
 import logging
 import sys
 
+from ipywidgets import interact, IntSlider
+
 try:
     from IPython.core.display import display, HTML
     from IPython.display import clear_output
@@ -30,6 +32,26 @@ class ViewerBase:
                 raise ViewerImportError(self.backend)
 
         return sys.modules[self.backend]
+
+    def view(self, i=0):
+        _pose = self.poses[i]
+        _pdbstring = self.pdbstrings[i]
+
+        return self.update_viewer(_pose, _pdbstring)
+
+    def get_decoy_widget(self):
+        if self.n_decoys > 1:
+            s_widget = IntSlider(
+                min=0,
+                max=self.n_decoys - 1,
+                description="Decoys",
+                continuous_update=self.continuous_update,
+            )
+            widget = interact(self.view, i=s_widget)
+        else:
+            widget = self.view()
+
+        return widget
 
     def __add__(self, other):
         self.modules += [other]

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import time
 
-from ipywidgets import interact, IntSlider
+from ipywidgets import interact, interactive, IntSlider
 from ipywidgets.widgets import Widget
 
 try:
@@ -87,7 +87,12 @@ class ViewerBase(WidgetsBase):
                     description="Decoys",
                     continuous_update=self.continuous_update,
                 )
-                interact(self.update_decoy, i=s_widget)
+                # interact(self.update_decoy, i=s_widget)
+                interactive_widget = interactive(self.update_decoy, i=s_widget)
+                # s_widget.observe(self.update_decoy, names="value")
+                display(interactive_widget, self.viewer)
+                # self.viewer.show()
+                self.update_decoy()
             else:
                 self.setup_viewer(self.poses[0], self.pdbstrings[0])
 

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -149,6 +149,15 @@ class Base3D:
         except NameError as e:
             _logger.debug(e)
 
+    def _in_notebook(self):
+        try:
+            get_ipython()
+            _in_notebook = True
+        except:
+            _in_notebook = False
+        finally:
+            return _in_notebook
+
     def add(self, other):
         """Add a module to the Viewer instance."""
         return self.__add__(other)
@@ -230,10 +239,11 @@ class ViewerBase(Base3D, WidgetsBase):
 
     def show(self):
         """Display Viewer in Jupyter notebook."""
-        self._toggle_scrolling()
-        self._toggle_window(self.window_size)
-        display(*self.get_widgets())
-        self.show_viewer()
+        if self._in_notebook():
+            self._toggle_scrolling()
+            self._toggle_window(self.window_size)
+            display(*self.get_widgets())
+            self.show_viewer()
 
 
 def expand_notebook():

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -63,12 +63,18 @@ class ViewerBase(WidgetsBase):
 
         return sys.modules[self.backend]
 
-    def update_decoy(self, i=0):
-        time.sleep(self.delay)
-        self.update_viewer(self.poses[i], self.pdbstrings[i])
+    def setup_viewer(self, _pose=None, _pdbstring=None):
+        """Setup Viewer in Jupyter notebook."""
+        self.remove_objects()
+        self.add_models(_pose=_pose, _pdbstring=_pdbstring)
+        self.apply_modules(_pose=_pose, _pdbstring=_pdbstring)
 
     def set_widgets(self, obj):
         self.widgets = _to_widgets(obj)
+
+    def update_decoy(self, i=0):
+        time.sleep(self.delay)
+        self.update_viewer(self.poses[i], self.pdbstrings[i])
 
     def show_widgets(self):
         if self.widgets is not None:
@@ -83,7 +89,7 @@ class ViewerBase(WidgetsBase):
                 )
                 interact(self.update_decoy, i=s_widget)
             else:
-                self.update_decoy()
+                self.setup_viewer(self.poses[0], self.pdbstrings[0])
 
     def show(self):
         """Display Viewer in Jupyter notebook."""

--- a/viewer3d/converters.py
+++ b/viewer3d/converters.py
@@ -33,12 +33,10 @@ def _to_poses_pdbstrings(packed_and_poses_and_pdbs):
     def to_pdbstring(obj):
         raise ViewerInputError(obj)
 
-    @to_pdbstring.register(type(None))
+    @to_pdbstring.register(PackedPose)
+    @to_pdbstring.register(Pose)
     def _(obj):
-        raise ViewerInputError(obj)
-
-    to_pdbstring.register(PackedPose, lambda obj: io.to_pdbstring(obj))
-    to_pdbstring.register(Pose, lambda obj: io.to_pdbstring(obj))
+        return io.to_pdbstring(obj)
 
     @to_pdbstring.register(str)
     def _(obj):

--- a/viewer3d/converters.py
+++ b/viewer3d/converters.py
@@ -95,7 +95,7 @@ def _to_widgets(objs) -> List[Widget]:
     _to_widget.register(Widget, lambda obj: obj)
 
     if objs is None:
-        _widgets = None
+        _widgets = []
     elif isinstance(objs, collections.abc.Iterable):
         _widgets = list(map(_to_widget, objs))
     else:

--- a/viewer3d/converters.py
+++ b/viewer3d/converters.py
@@ -5,6 +5,7 @@ import pyrosetta.distributed.io as io
 import os
 
 from functools import singledispatch
+from ipywidgets.widgets import Widget
 from pyrosetta import Pose
 from pyrosetta.distributed.packed_pose.core import PackedPose
 from pyrosetta.rosetta.core.pose.full_model_info import (
@@ -12,6 +13,7 @@ from pyrosetta.rosetta.core.pose.full_model_info import (
     get_chains_from_pdb_info,
 )
 from pyrosetta.rosetta.core.select import get_residues_from_subset
+from typing import List
 
 from viewer3d.exceptions import ViewerInputError
 
@@ -80,6 +82,26 @@ def _to_0_if_le_0(obj):
 
 def _to_1_if_gt_1(obj):
     return 1 if isinstance(obj, (float, int)) and obj > 1 else obj
+
+
+def _to_widgets(objs) -> List[Widget]:
+    @singledispatch
+    def _to_widget(obj):
+        raise ValueError(
+            "The 'widgets' viewer attribute must be an instance of `Widget` "
+            + f"or an iterable of `Widget` objects. Received: {type(obj)}"
+        )
+
+    _to_widget.register(Widget, lambda obj: obj)
+
+    if objs is None:
+        _widgets = None
+    elif isinstance(objs, collections.abc.Iterable):
+        _widgets = list(map(_to_widget, objs))
+    else:
+        _widgets = [_to_widget(objs)]
+
+    return _widgets
 
 
 def _pose_to_residue_chain_tuples(pose, residue_selector, logger=_logger):

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -62,11 +62,11 @@ class Py3DmolViewer(ViewerBase):
     def update_viewer(self, _pose=None, _pdbstring=None):
         """Update Py3DmolViewer in Jupyter notebook."""
         self.setup_viewer(_pose=_pose, _pdbstring=_pose)
-        if self._was_show_called:
-            self.viewer.update()
+        # if self._was_show_called:
+        self.viewer.update()
 
     def show_viewer(self):
-        self.viewer.show()
+        # self.viewer.show()
         self._was_show_called = True
 
 

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -5,11 +5,10 @@ import os
 import pyrosetta.distributed.io as io
 
 from ipywidgets import interact, IntSlider
-from ipywidgets.widgets import Widget
 from IPython.display import display
 from pyrosetta.rosetta.core.pose import Pose
 from pyrosetta.distributed.packed_pose.core import PackedPose
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, Tuple, Union
 
 from viewer3d.base import ViewerBase
 from viewer3d.config import BACKENDS
@@ -31,11 +30,6 @@ class Py3DmolViewer(ViewerBase):
     delay = attr.ib(type=float)
     continuous_update = attr.ib(type=bool)
     backend = attr.ib(type=str)
-    # widget = attr.ib(
-    #     type=Optional[Widget],
-    #     default=None,
-    #     validator=attr.validators.instance_of((type(None), Widget)),
-    # )
     _was_show_called = attr.ib(type=bool, default=False, init=False)
 
     def __attrs_post_init__(self):
@@ -52,6 +46,15 @@ class Py3DmolViewer(ViewerBase):
             "SAS": self.py3Dmol.SAS,
         }
 
+    def apply_modules(self, _pose=None, _pdbstring=None):
+        for _module in self.modules:
+            self.viewer = _module.apply_py3Dmol(
+                self.viewer,
+                _pose,
+                _pdbstring,
+                surface_types_dict=self.surface_types_dict,
+            )
+
     def update_viewer(self, _pose=None, _pdbstring=None):
         """Update Py3DmolViewer in Jupyter notebook."""
         self.viewer.removeAllLabels()
@@ -63,14 +66,14 @@ class Py3DmolViewer(ViewerBase):
             self.viewer.addModels(io.to_pdbstring(_pose), "pdb")
         else:
             self.viewer.addModels(_pdbstring, "pdb")
-
-        for module in self.modules:
-            self.viewer = module.apply_py3Dmol(
-                self.viewer,
-                _pose,
-                _pdbstring,
-                surface_types_dict=self.surface_types_dict,
-            )
+        # for module in self.modules:
+        #     self.viewer = module.apply_py3Dmol(
+        #         self.viewer,
+        #         _pose,
+        #         _pdbstring,
+        #         surface_types_dict=self.surface_types_dict,
+        #     )
+        self.apply_modules(_pose=_pose, _pdbstring=_pdbstring)
 
         if self._was_show_called:
             self.viewer.update()

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -29,7 +29,7 @@ class Py3DmolViewer(ViewerBase):
     delay = attr.ib(type=float)
     continuous_update = attr.ib(type=bool)
     backend = attr.ib(type=str)
-    _viewer_is_init = attr.ib(type=bool, default=False, init=False)
+    _was_show_called = attr.ib(type=bool, default=False, init=False)
 
     def __attrs_post_init__(self):
         self._toggle_window(self.window_size)
@@ -66,15 +66,14 @@ class Py3DmolViewer(ViewerBase):
                 surface_types_dict=self.surface_types_dict,
             )
 
-        if self._viewer_is_init:
+        if self._was_show_called:
             self.viewer.update()
-        else:
-            self._viewer_is_init = True
 
     def show(self):
         """Display Py3DmolViewer in Jupyter notebook."""
         self.setup()
         self.viewer.show()
+        self._was_show_called = True
 
 
 @attr.s(kw_only=True, slots=False, frozen=False)

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -6,13 +6,13 @@ import pyrosetta.distributed.io as io
 
 from ipywidgets import interact, IntSlider
 from IPython.display import display
-from pyrosetta.rosetta.core.pose import Pose
+from pyrosetta import Pose
 from pyrosetta.distributed.packed_pose.core import PackedPose
 from typing import Iterable, Tuple, Union
 
-from viewer3d.base import ViewerBase
+from viewer3d.base import ViewerBase, WidgetsBase
 from viewer3d.config import BACKENDS
-from viewer3d.converters import _to_float, _to_poses_pdbstrings
+from viewer3d.converters import _to_float, _to_poses_pdbstrings, _to_widgets
 from viewer3d.modules import ModuleBase
 from viewer3d.validators import _validate_int_float, _validate_window_size
 
@@ -22,14 +22,6 @@ _logger = logging.getLogger("viewer3d.core")
 
 @attr.s(kw_only=True, slots=False, frozen=False)
 class Py3DmolViewer(ViewerBase):
-    poses = attr.ib(type=Pose)
-    pdbstrings = attr.ib(type=PackedPose)
-    n_decoys = attr.ib(type=int)
-    window_size = attr.ib(type=Tuple[Union[int, float]])
-    modules = attr.ib(type=list)
-    delay = attr.ib(type=float)
-    continuous_update = attr.ib(type=bool)
-    backend = attr.ib(type=str)
     _was_show_called = attr.ib(type=bool, default=False, init=False)
 
     def __attrs_post_init__(self):
@@ -76,15 +68,6 @@ class Py3DmolViewer(ViewerBase):
 
 @attr.s(kw_only=True, slots=False, frozen=False)
 class NGLviewViewer(ViewerBase):
-    poses = attr.ib(type=Pose)
-    pdbstrings = attr.ib(type=PackedPose)
-    n_decoys = attr.ib(type=int)
-    window_size = attr.ib(type=Tuple[Union[int, float]])
-    modules = attr.ib(type=list)
-    delay = attr.ib(type=float)
-    continuous_update = attr.ib(type=bool)
-    backend = attr.ib(type=str)
-
     def __attrs_post_init__(self):
         self.nglview = self._maybe_import_backend()
         self.viewer = self.nglview.widget.NGLWidget()
@@ -115,15 +98,6 @@ class NGLviewViewer(ViewerBase):
 
 @attr.s(kw_only=True, slots=False, frozen=False)
 class PyMOLViewer(ViewerBase):
-    poses = attr.ib(type=Pose)
-    pdbstrings = attr.ib(type=PackedPose)
-    n_decoys = attr.ib(type=int)
-    window_size = attr.ib(type=Tuple[Union[int, float]])
-    modules = attr.ib(type=list)
-    delay = attr.ib(type=float)
-    continuous_update = attr.ib(type=bool)
-    backend = attr.ib(type=str)
-
     def __attrs_post_init__(self):
         self.pymol = self._maybe_import_backend()
 
@@ -147,7 +121,7 @@ class PyMOLViewer(ViewerBase):
 
 
 @attr.s(kw_only=True, slots=False, frozen=False)
-class SetupViewer:
+class SetupViewer(WidgetsBase):
     packed_and_poses_and_pdbs = attr.ib(
         type=Union[PackedPose, Pose, Iterable[Union[PackedPose, Pose]], None],
         default=None,

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -101,18 +101,23 @@ class NGLviewViewer(ViewerBase):
     backend = attr.ib(type=str)
 
     def __attrs_post_init__(self):
-        self._toggle_window(self.window_size)
+        # self._toggle_window(self.window_size)
         self.nglview = self._maybe_import_backend()
-
-        raise NotImplementedError(
-            f"{self.__class__.__name__} is not currently supported."
-        )
 
     def show(self):
         """Display NGLviewViewer in Jupyter notebook."""
 
         def view(i=0):
-            _viewer = None  # TODO
+            _pose = self.poses[i]
+            _pdbstring = self.pdbstrings[i]
+
+            if _pose is not None:
+                _viewer = self.nglview.show_rosetta(_pose)
+            else:
+                raise NotImplementedError(
+                    f"PDB strings are currently not supported using the `{backend}` backend."
+                )
+
             for module in self.modules:
                 _viewer = module.apply_nglview(
                     _viewer,
@@ -120,12 +125,7 @@ class NGLviewViewer(ViewerBase):
                     _pdbstring,
                 )
 
-            self._clear_output()
-
-            if _pose is not None and _pose.pdb_info() and _pose.pdb_info().name():
-                _logger.debug("Decoy {0}: {1}".format(i, _pose.pdb_info().name()))
-
-            return _viewer.show()
+            return _viewer.display(gui=True)
 
         time.sleep(self.delay)
 

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -42,6 +42,7 @@ class Py3DmolViewer(ViewerBase):
         }
 
     def update_viewer(self, _pose, _pdbstring):
+        """Update Py3DmolViewer in Jupyter notebook."""
         time.sleep(self.delay)
         self.viewer.removeAllLabels()
         self.viewer.removeAllModels()
@@ -91,6 +92,7 @@ class NGLviewViewer(ViewerBase):
         self.viewer = self.nglview.widget.NGLWidget()
 
     def update_viewer(self, _pose, _pdbstring):
+        """Update NGLviewViewer in Jupyter notebook."""
         time.sleep(self.delay)
 
         for component_id in self.viewer._ngl_component_ids:
@@ -137,6 +139,7 @@ class PyMOLViewer(ViewerBase):
         )
 
     def update_viewer(self, _pose, _pdbstring):
+        """Update PyMOLViewer."""
         pass
 
     def show(self):

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -61,20 +61,11 @@ class Py3DmolViewer(ViewerBase):
         self.viewer.removeAllModels()
         self.viewer.removeAllShapes()
         self.viewer.removeAllSurfaces()
-
         if _pose is not None:
             self.viewer.addModels(io.to_pdbstring(_pose), "pdb")
         else:
             self.viewer.addModels(_pdbstring, "pdb")
-        # for module in self.modules:
-        #     self.viewer = module.apply_py3Dmol(
-        #         self.viewer,
-        #         _pose,
-        #         _pdbstring,
-        #         surface_types_dict=self.surface_types_dict,
-        #     )
         self.apply_modules(_pose=_pose, _pdbstring=_pdbstring)
-
         if self._was_show_called:
             self.viewer.update()
 
@@ -98,23 +89,24 @@ class NGLviewViewer(ViewerBase):
         self.nglview = self._maybe_import_backend()
         self.viewer = self.nglview.widget.NGLWidget()
 
-    def update_viewer(self, _pose=None, _pdbstring=None):
-        """Update NGLviewViewer in Jupyter notebook."""
-        for component_id in self.viewer._ngl_component_ids:
-            self.viewer.remove_component(component_id)
-
-        if _pose is not None:
-            structure = self.nglview.adaptor.RosettaStructure(_pose)
-        else:
-            structure = self.nglview.adaptor.TextStructure(_pdbstring, ext="pdb")
-        self.viewer.add_structure(structure)
-
+    def apply_modules(self, _pose=None, _pdbstring=None):
         for module in self.modules:
             self.viewer = module.apply_nglview(
                 self.viewer,
                 _pose,
                 _pdbstring,
             )
+
+    def update_viewer(self, _pose=None, _pdbstring=None):
+        """Update NGLviewViewer in Jupyter notebook."""
+        for component_id in self.viewer._ngl_component_ids:
+            self.viewer.remove_component(component_id)
+        if _pose is not None:
+            structure = self.nglview.adaptor.RosettaStructure(_pose)
+        else:
+            structure = self.nglview.adaptor.TextStructure(_pdbstring, ext="pdb")
+        self.viewer.add_structure(structure)
+        self.apply_modules(_pose=_pose, _pdbstring=_pdbstring)
 
     def show_viewer(self):
         self.viewer.display(gui=True, style="ngl")

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -3,7 +3,6 @@ import collections
 import logging
 import os
 import pyrosetta.distributed.io as io
-import time
 
 from pyrosetta.rosetta.core.pose import Pose
 from pyrosetta.distributed.packed_pose.core import PackedPose
@@ -45,9 +44,8 @@ class Py3DmolViewer(ViewerBase):
             "SAS": self.py3Dmol.SAS,
         }
 
-    def update(self, _pose, _pdbstring):
+    def update_viewer(self, _pose, _pdbstring):
         """Update Py3DmolViewer in Jupyter notebook."""
-        time.sleep(self.delay)
         self.viewer.removeAllLabels()
         self.viewer.removeAllModels()
         self.viewer.removeAllShapes()
@@ -91,10 +89,8 @@ class NGLviewViewer(ViewerBase):
         self.nglview = self._maybe_import_backend()
         self.viewer = self.nglview.widget.NGLWidget()
 
-    def update(self, _pose, _pdbstring):
+    def update_viewer(self, _pose, _pdbstring):
         """Update NGLviewViewer in Jupyter notebook."""
-        time.sleep(self.delay)
-
         for component_id in self.viewer._ngl_component_ids:
             self.viewer.remove_component(component_id)
 
@@ -136,7 +132,7 @@ class PyMOLViewer(ViewerBase):
             f"{self.__class__.__name__} is not currently supported."
         )
 
-    def update(self, _pose, _pdbstring):
+    def update_viewer(self, _pose, _pdbstring):
         """Update PyMOLViewer."""
         pass
 

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -97,12 +97,10 @@ class NGLviewViewer(ViewerBase):
             self.viewer.remove_component(component_id)
 
         if _pose is not None:
-            self.structure = self.nglview.adaptor.RosettaStructure(_pose)
-            self.viewer.add_structure(self.structure)
+            structure = self.nglview.adaptor.RosettaStructure(_pose)
         else:
-            raise NotImplementedError(
-                f"PDB strings are currently not supported using the `{backend}` backend."
-            )
+            structure = self.nglview.adaptor.TextStructure(_pdbstring, ext="pdb")
+        self.viewer.add_structure(structure)
 
         for module in self.modules:
             self.viewer = module.apply_nglview(

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -4,9 +4,11 @@ import logging
 import os
 import pyrosetta.distributed.io as io
 
+from ipywidgets.widgets import Widget
+from IPython.display import display
 from pyrosetta.rosetta.core.pose import Pose
 from pyrosetta.distributed.packed_pose.core import PackedPose
-from typing import Iterable, Tuple, Union
+from typing import Iterable, Optional, Tuple, Union
 
 from viewer3d.base import ViewerBase
 from viewer3d.config import BACKENDS
@@ -28,6 +30,11 @@ class Py3DmolViewer(ViewerBase):
     delay = attr.ib(type=float)
     continuous_update = attr.ib(type=bool)
     backend = attr.ib(type=str)
+    widget = attr.ib(
+        type=Optional[Widget],
+        default=None,
+        validator=attr.validators.instance_of((type(None), Widget)),
+    )
     _was_show_called = attr.ib(type=bool, default=False, init=False)
 
     def __attrs_post_init__(self):
@@ -44,7 +51,7 @@ class Py3DmolViewer(ViewerBase):
             "SAS": self.py3Dmol.SAS,
         }
 
-    def update_viewer(self, _pose, _pdbstring):
+    def update_viewer(self, _pose=None, _pdbstring=None):
         """Update Py3DmolViewer in Jupyter notebook."""
         self.viewer.removeAllLabels()
         self.viewer.removeAllModels()
@@ -67,8 +74,17 @@ class Py3DmolViewer(ViewerBase):
         if self._was_show_called:
             self.viewer.update()
 
+    # def setup_widgets(self):
+    #     if self.widget is not None:
+    #         display(self.widget, self.viewer)
+    #     else:
+    #         self.setup()
+    #         self.viewer.show()
+    #         self._was_show_called = True
+
     def show(self):
         """Display Py3DmolViewer in Jupyter notebook."""
+        # self.setup_widgets()
         self.setup()
         self.viewer.show()
         self._was_show_called = True

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pyrosetta.distributed.io as io
 
+from ipywidgets import interact, IntSlider
 from ipywidgets.widgets import Widget
 from IPython.display import display
 from pyrosetta.rosetta.core.pose import Pose
@@ -30,11 +31,11 @@ class Py3DmolViewer(ViewerBase):
     delay = attr.ib(type=float)
     continuous_update = attr.ib(type=bool)
     backend = attr.ib(type=str)
-    widget = attr.ib(
-        type=Optional[Widget],
-        default=None,
-        validator=attr.validators.instance_of((type(None), Widget)),
-    )
+    # widget = attr.ib(
+    #     type=Optional[Widget],
+    #     default=None,
+    #     validator=attr.validators.instance_of((type(None), Widget)),
+    # )
     _was_show_called = attr.ib(type=bool, default=False, init=False)
 
     def __attrs_post_init__(self):
@@ -74,18 +75,7 @@ class Py3DmolViewer(ViewerBase):
         if self._was_show_called:
             self.viewer.update()
 
-    # def setup_widgets(self):
-    #     if self.widget is not None:
-    #         display(self.widget, self.viewer)
-    #     else:
-    #         self.setup()
-    #         self.viewer.show()
-    #         self._was_show_called = True
-
-    def show(self):
-        """Display Py3DmolViewer in Jupyter notebook."""
-        # self.setup_widgets()
-        self.setup()
+    def show_viewer(self):
         self.viewer.show()
         self._was_show_called = True
 
@@ -105,7 +95,7 @@ class NGLviewViewer(ViewerBase):
         self.nglview = self._maybe_import_backend()
         self.viewer = self.nglview.widget.NGLWidget()
 
-    def update_viewer(self, _pose, _pdbstring):
+    def update_viewer(self, _pose=None, _pdbstring=None):
         """Update NGLviewViewer in Jupyter notebook."""
         for component_id in self.viewer._ngl_component_ids:
             self.viewer.remove_component(component_id)
@@ -123,9 +113,7 @@ class NGLviewViewer(ViewerBase):
                 _pdbstring,
             )
 
-    def show(self):
-        """Display NGLviewViewer in Jupyter notebook."""
-        self.setup()
+    def show_viewer(self):
         self.viewer.display(gui=True, style="ngl")
         self.viewer._ipython_display_()
 

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -47,17 +47,21 @@ class Py3DmolViewer(ViewerBase):
                 surface_types_dict=self.surface_types_dict,
             )
 
-    def update_viewer(self, _pose=None, _pdbstring=None):
-        """Update Py3DmolViewer in Jupyter notebook."""
-        self.viewer.removeAllLabels()
-        self.viewer.removeAllModels()
-        self.viewer.removeAllShapes()
-        self.viewer.removeAllSurfaces()
+    def add_models(self, _pose=None, _pdbstring=None):
         if _pose is not None:
             self.viewer.addModels(io.to_pdbstring(_pose), "pdb")
         else:
             self.viewer.addModels(_pdbstring, "pdb")
-        self.apply_modules(_pose=_pose, _pdbstring=_pdbstring)
+
+    def remove_objects(self):
+        self.viewer.removeAllLabels()
+        self.viewer.removeAllModels()
+        self.viewer.removeAllShapes()
+        self.viewer.removeAllSurfaces()
+
+    def update_viewer(self, _pose=None, _pdbstring=None):
+        """Update Py3DmolViewer in Jupyter notebook."""
+        self.setup_viewer(_pose=_pose, _pdbstring=_pose)
         if self._was_show_called:
             self.viewer.update()
 
@@ -73,23 +77,26 @@ class NGLviewViewer(ViewerBase):
         self.viewer = self.nglview.widget.NGLWidget()
 
     def apply_modules(self, _pose=None, _pdbstring=None):
-        for module in self.modules:
-            self.viewer = module.apply_nglview(
+        for _module in self.modules:
+            self.viewer = _module.apply_nglview(
                 self.viewer,
                 _pose,
                 _pdbstring,
             )
 
-    def update_viewer(self, _pose=None, _pdbstring=None):
-        """Update NGLviewViewer in Jupyter notebook."""
-        for component_id in self.viewer._ngl_component_ids:
-            self.viewer.remove_component(component_id)
+    def add_models(self, _pose=None, _pdbstring=None):
         if _pose is not None:
             structure = self.nglview.adaptor.RosettaStructure(_pose)
         else:
             structure = self.nglview.adaptor.TextStructure(_pdbstring, ext="pdb")
         self.viewer.add_structure(structure)
-        self.apply_modules(_pose=_pose, _pdbstring=_pdbstring)
+
+    def remove_objects(self):
+        for component_id in self.viewer._ngl_component_ids:
+            self.viewer.remove_component(component_id)
+
+    def update_viewer(self, _pose=None, _pdbstring=None):
+        self.setup_viewer(_pose=_pose, _pdbstring=_pdbstring)
 
     def show_viewer(self):
         self.viewer.display(gui=True, style="ngl")

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -143,7 +143,7 @@ class setDisulfides(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self):
+    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -262,7 +262,7 @@ class setHydrogenBonds(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self):
+    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -357,7 +357,7 @@ class setHydrogens(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self):
+    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -602,7 +602,7 @@ class setStyle(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self):
+    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -732,7 +732,7 @@ class setSurface(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self):
+    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -768,7 +768,7 @@ class setZoom(ModuleBase):
         viewer.zoom(self.factor)
         return viewer
 
-    def apply_nglview(self):
+    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -814,7 +814,7 @@ class setZoomTo(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self):
+    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -602,8 +602,76 @@ class setStyle(ModuleBase):
 
         return viewer
 
+    @pyrosetta.distributed.requires_init
     def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
-        raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
+        # raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
+        if self.command:
+            pass
+        else:
+            if self.residue_selector:
+                if pose is None:
+                    pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
+
+                resi, chain = _pose_to_residue_chain_tuples(pose, self.residue_selector)
+
+                if (not resi) and (not chain):
+                    pass
+                else:
+                    if self.cartoon:
+                        pass
+                        # viewer.setStyle(
+                        #     {"resi": resi, "chain": chain},
+                        #     {
+                        #         "cartoon": {"color": self.cartoon_color},
+                        #         self.style: {
+                        #             "colorscheme": self.colorscheme,
+                        #             "radius": self.radius,
+                        #         },
+                        #     },
+                        # )
+                    else:
+                        pass
+                        # viewer.setStyle(
+                        #     {"resi": resi, "chain": chain},
+                        #     {
+                        #         self.style: {
+                        #             "colorscheme": self.colorscheme,
+                        #             "radius": self.radius,
+                        #         }
+                        #     },
+                        # )
+                    # if self.label:
+                    #     raise NotImplementedError(self.label)
+                    #     viewer.addResLabels(
+                    #         {"resi": resi, "chain": chain},
+                    #         {
+                    #             "fontSize": self.label_fontsize,
+                    #             "showBackground": self.label_background,
+                    #             "fontColor": self.label_fontcolor,
+                    #         },
+                    #     )
+            else:
+                if self.cartoon:
+                    viewer.setStyle(
+                        {
+                            "cartoon": {"color": self.cartoon_color},
+                            self.style: {
+                                "colorscheme": self.colorscheme,
+                                "radius": self.radius,
+                            },
+                        }
+                    )
+                else:
+                    viewer.setStyle(
+                        {
+                            self.style: {
+                                "colorscheme": self.colorscheme,
+                                "radius": self.radius,
+                            }
+                        }
+                    )
+
+        return viewer
 
     def apply_pymol(self):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[2])

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -54,12 +54,12 @@ class setBackgroundColor(ModuleBase):
         converter=attr.converters.default_if_none(default=0xFFFFFFFF),
     )
 
-    def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
+    def apply_py3Dmol(self, viewer, pose, pdbstring):
         viewer.setBackgroundColor(self.color)
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+    def apply_nglview(self, viewer, pose, pdbstring):
         viewer.background = self.color
 
         return viewer
@@ -107,7 +107,7 @@ class setDisulfides(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
+    def apply_py3Dmol(self, viewer, pose, pdbstring):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -143,7 +143,7 @@ class setDisulfides(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+    def apply_nglview(self, viewer, pose, pdbstring):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -204,7 +204,7 @@ class setHydrogenBonds(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
+    def apply_py3Dmol(self, viewer, pose, pdbstring):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -262,7 +262,7 @@ class setHydrogenBonds(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+    def apply_nglview(self, viewer, pose, pdbstring):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -332,7 +332,7 @@ class setHydrogens(ModuleBase):
         return _viewer
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
+    def apply_py3Dmol(self, viewer, pose, pdbstring):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -357,7 +357,7 @@ class setHydrogens(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+    def apply_nglview(self, viewer, pose, pdbstring):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -468,7 +468,9 @@ class setStyle(ModuleBase):
     residue_selector = attr.ib(
         default=None,
         type=Optional[ResidueSelector],
-        validator=attr.validators.instance_of((ResidueSelector, type(None))),
+        validator=attr.validators.optional(
+            attr.validators.instance_of(ResidueSelector)
+        ),
     )
     cartoon = attr.ib(
         default=True,
@@ -533,7 +535,7 @@ class setStyle(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
+    def apply_py3Dmol(self, viewer, pose, pdbstring):
         if self.command:
             if isinstance(self.command, tuple):
                 viewer.setStyle(*self.command)
@@ -603,7 +605,7 @@ class setStyle(ModuleBase):
         return viewer
 
     @pyrosetta.distributed.requires_init
-    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+    def apply_nglview(self, viewer, pose, pdbstring):
         # raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
         if self.command:
             pass
@@ -749,7 +751,7 @@ class setSurface(ModuleBase):
         type=str,
         validator=[
             attr.validators.instance_of(str),
-            attr.validators.in_(("VDW", "MS", "SES", "SAS")),
+            attr.validators.in_(("VDW", "MS", "SAS", "SES")),
         ],
     )
     opacity = attr.ib(
@@ -770,7 +772,14 @@ class setSurface(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring, surface_types_dict=None, **kwargs):
+    def apply_py3Dmol(self, viewer, pose, pdbstring):
+        py3Dmol = sys.modules["py3Dmol"]
+        surface_types_dict: Dict[str, int] = {
+            "VDW": py3Dmol.VDW,
+            "MS": py3Dmol.MS,
+            "SAS": py3Dmol.SAS,
+            "SES": py3Dmol.SES,
+        }
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -800,7 +809,7 @@ class setSurface(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+    def apply_nglview(self, viewer, pose, pdbstring):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -832,11 +841,11 @@ class setZoom(ModuleBase):
         validator=attr.validators.instance_of((float, int)),
     )
 
-    def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
+    def apply_py3Dmol(self, viewer, pose, pdbstring):
         viewer.zoom(self.factor)
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+    def apply_nglview(self, viewer, pose, pdbstring):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -869,7 +878,7 @@ class setZoomTo(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
+    def apply_py3Dmol(self, viewer, pose, pdbstring):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -882,7 +891,7 @@ class setZoomTo(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+    def apply_nglview(self, viewer, pose, pdbstring):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -58,8 +58,10 @@ class setBackgroundColor(ModuleBase):
         viewer.setBackgroundColor(self.color)
         return viewer
 
-    def apply_nglview(self):
-        raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
+    def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
+        viewer.background = self.color
+        return viewer
+        # raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[2])

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -108,7 +108,7 @@ class setDisulfides(ModuleBase):
 
     @pyrosetta.distributed.requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
-        if pose is not None:
+        if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
         cys_res = []
@@ -205,7 +205,7 @@ class setHydrogenBonds(ModuleBase):
 
     @pyrosetta.distributed.requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
-        if pose is not None:
+        if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
         hbond_set = pose.get_hbonds()
@@ -333,7 +333,7 @@ class setHydrogens(ModuleBase):
 
     @pyrosetta.distributed.requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
-        if pose is not None:
+        if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
         if pose.is_fullatom():
@@ -541,7 +541,7 @@ class setStyle(ModuleBase):
                 viewer.setStyle(self.command)
         else:
             if self.residue_selector:
-                if pose is not None:
+                if pose is None:
                     pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
                 resi, chain = _pose_to_residue_chain_tuples(pose, self.residue_selector)
@@ -703,7 +703,7 @@ class setSurface(ModuleBase):
 
     @pyrosetta.distributed.requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, surface_types_dict=None, **kwargs):
-        if pose is not None:
+        if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
         resi, chain = _pose_to_residue_chain_tuples(pose, self.residue_selector)
@@ -802,7 +802,7 @@ class setZoomTo(ModuleBase):
 
     @pyrosetta.distributed.requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
-        if pose is not None:
+        if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
         resi, chain = _pose_to_residue_chain_tuples(pose, self.residue_selector)

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -56,12 +56,13 @@ class setBackgroundColor(ModuleBase):
 
     def apply_py3Dmol(self, viewer, pose, pdbstring, **kwargs):
         viewer.setBackgroundColor(self.color)
+
         return viewer
 
     def apply_nglview(self, viewer, pose, pdbstring, **kwargs):
         viewer.background = self.color
+
         return viewer
-        # raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[2])

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -5,6 +5,7 @@ Display preset custom viewers for routine visualizations.
 import logging
 import viewer3d
 
+from pyrosetta.distributed import requires_init
 from pyrosetta.rosetta.core.chemical import ResidueProperty
 from pyrosetta.rosetta.core.select.residue_selector import (
     LayerSelector,
@@ -121,3 +122,124 @@ def templatePreset(packed_and_poses_and_pdbs=None, *args, **kwargs):
     # Add custom Viewer commands here
 
     return view()
+
+
+@requires_init
+def makeBundle():
+    """
+    Add a description of the preset Viewer here
+    """
+    import pyrosetta
+
+    from pyrosetta.rosetta.protocols.helical_bundle import (
+        BPC_delta_omega0,
+        BPC_r0,
+        BPC_invert_helix,
+        MakeBundle,
+    )
+    from ipywidgets.widgets import (
+        IntSlider,
+        FloatSlider,
+        Checkbox,
+        ToggleButtons,
+        HBox,
+        VBox,
+        Button,
+        Text,
+    )
+    from IPython.display import display
+
+    pose = pyrosetta.Pose()
+    view = viewer3d.init(
+        packed_and_poses_and_pdbs=pose, backend="py3Dmol"
+    ) + viewer3d.setStyle(style="stick", colorscheme="lightgreyCarbon", radius=0.15)
+
+    mb = MakeBundle()
+    mb.set_reset_pose(True)
+    mb.set_use_degrees(True)
+    num_helices = 4
+
+    def update_bundle():
+        mb.apply(pose)
+        view.update_viewer(pose)
+
+    def initialize_bundle():
+        for i in range(1, num_helices + 1):
+            mb.add_helix()
+            mb.helix(i).set_helix_length(length.value)
+            mb.helix(i).calculator_op().real_parameter(BPC_delta_omega0).set_value(
+                360 / num_helices * (i - 1)
+            )
+            mb.helix(i).calculator_op().real_parameter(BPC_r0).set_value(
+                r0.value
+            )  # in angstrem
+
+    def on_length_change(change):
+        for i in range(1, num_helices + 1):
+            if chosen_helix.value == "all" or chosen_helix.value == i:
+                mb.helix(i).set_helix_length(length.value)
+        update_bundle()
+
+    def on_param_change(change):
+        """Takes the name of the parameter from the change.owner.description and se"""
+        for i in range(1, num_helices + 1):
+            if chosen_helix.value == "all" or chosen_helix.value == i:
+                param_enum = getattr(
+                    pyrosetta.rosetta.protocols.helical_bundle,
+                    f"BPC_{change.owner.description}",
+                )
+                mb.helix(i).calculator_op().real_parameter(param_enum).set_value(
+                    change.new
+                )
+        update_bundle()
+
+    def on_invert_change(change):
+        for i in range(1, num_helices + 1):
+            if chosen_helix.value == "all" or chosen_helix.value == i:
+                mb.helix(i).calculator_op().boolean_parameter(
+                    BPC_invert_helix
+                ).set_value(bool(change.new))
+        update_bundle()
+
+    chosen_helix = ToggleButtons(
+        options=["all", 1, 2, 3, 4], description="chosen_helix"
+    )
+    r0 = FloatSlider(min=1, max=10, step=0.1, value=5, description="r0")
+    length = IntSlider(min=14, max=50, value=28, description="length")
+    omega0 = FloatSlider(min=-5, max=5, step=0.1, value=0, description="omega0")
+    delta_omega1 = FloatSlider(
+        min=0,
+        max=360,
+        description="delta_omega1",
+        style={"description_width": "initial"},
+    )
+    invert = Checkbox(value=False, description="invert")
+
+    length.observe(on_length_change, names="value")
+    r0.observe(on_param_change, names="value")
+    omega0.observe(on_param_change, names="value")
+    delta_omega1.observe(on_param_change, names="value")
+    invert.observe(on_invert_change, names="value")
+
+    save_button = Button(description="save PDB")
+    save_edit = Text(value="bundle.pdb")
+
+    def save_pdb(sender):
+        pose.dump_pdb(save_edit.value)
+
+    save_button.on_click(save_pdb)
+    save_box = HBox([save_button, save_edit])
+
+    display(
+        chosen_helix,
+        length,
+        r0,
+        omega0,
+        delta_omega1,
+        invert,
+        save_box,
+    )
+    view.viewer.show()
+    view._was_show_called = True
+    initialize_bundle()
+    update_bundle()

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -125,7 +125,9 @@ def templatePreset(packed_and_poses_and_pdbs=None, *args, **kwargs):
 
 
 @requires_init
-def makeBundle(aa="VAL", num_helices=4, backend="py3Dmol", continuous_update=True):
+def makeBundle(
+    modules=[], aa="VAL", num_helices=4, backend="py3Dmol", continuous_update=True
+):
     """
     Add a description of the preset Viewer here
     """
@@ -157,41 +159,42 @@ def makeBundle(aa="VAL", num_helices=4, backend="py3Dmol", continuous_update=Tru
     )
     from pyrosetta.rosetta.utility import vector1_unsigned_long
 
-    core_selector = LayerSelector()
-    core_selector.set_layers(True, False, False)
-    boundary_selector = LayerSelector()
-    boundary_selector.set_layers(False, True, False)
-    surface_selector = LayerSelector()
-    surface_selector.set_layers(False, False, True)
-    modules = [
-        viewer3d.setStyle(
-            residue_selector=core_selector,
-            cartoon=True,
-            cartoon_color="black",
-            colorscheme="blackCarbon",
-            style="stick",
-            radius=0.25,
-            label=False,
-        ),
-        viewer3d.setStyle(
-            residue_selector=boundary_selector,
-            cartoon=True,
-            cartoon_color="grey",
-            colorscheme="greyCarbon",
-            style="stick",
-            radius=0.25,
-            label=False,
-        ),
-        viewer3d.setStyle(
-            residue_selector=surface_selector,
-            cartoon=True,
-            cartoon_color="white",
-            colorscheme="whiteCarbon",
-            style="stick",
-            radius=0.25,
-            label=False,
-        ),
-    ]
+    if not modules:
+        core_selector = LayerSelector()
+        core_selector.set_layers(True, False, False)
+        boundary_selector = LayerSelector()
+        boundary_selector.set_layers(False, True, False)
+        surface_selector = LayerSelector()
+        surface_selector.set_layers(False, False, True)
+        modules = [
+            viewer3d.setStyle(
+                residue_selector=core_selector,
+                cartoon=True,
+                cartoon_color="black",
+                colorscheme="blackCarbon",
+                style="stick",
+                radius=0.25,
+                label=False,
+            ),
+            viewer3d.setStyle(
+                residue_selector=boundary_selector,
+                cartoon=True,
+                cartoon_color="grey",
+                colorscheme="greyCarbon",
+                style="stick",
+                radius=0.25,
+                label=False,
+            ),
+            viewer3d.setStyle(
+                residue_selector=surface_selector,
+                cartoon=True,
+                cartoon_color="white",
+                colorscheme="whiteCarbon",
+                style="stick",
+                radius=0.25,
+                label=False,
+            ),
+        ]
 
     pose = pyrosetta.Pose()
     view = viewer3d.init(

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -150,9 +150,11 @@ def makeBundle():
     from IPython.display import display
 
     pose = pyrosetta.Pose()
-    view = viewer3d.init(
-        packed_and_poses_and_pdbs=pose, backend="py3Dmol"
-    ) + viewer3d.setStyle(style="stick", colorscheme="lightgreyCarbon", radius=0.15)
+    view = (
+        viewer3d.init(packed_and_poses_and_pdbs=pose, backend="nglview")
+        # + viewer3d.setStyle(style="stick", colorscheme="lightgreyCarbon", radius=0.15)
+        + viewer3d.setBackgroundColor(color="black")
+    )
 
     mb = MakeBundle()
     mb.set_reset_pose(True)
@@ -204,14 +206,36 @@ def makeBundle():
     chosen_helix = ToggleButtons(
         options=["all", 1, 2, 3, 4], description="chosen_helix"
     )
-    r0 = FloatSlider(min=1, max=10, step=0.1, value=5, description="r0")
-    length = IntSlider(min=14, max=50, value=28, description="length")
-    omega0 = FloatSlider(min=-5, max=5, step=0.1, value=0, description="omega0")
+    continuous_update = False
+    r0 = FloatSlider(
+        min=1,
+        max=10,
+        step=0.1,
+        value=5,
+        description="r0",
+        continuous_update=continuous_update,
+    )
+    length = IntSlider(
+        min=14,
+        max=50,
+        value=28,
+        description="length",
+        continuous_update=continuous_update,
+    )
+    omega0 = FloatSlider(
+        min=-5,
+        max=5,
+        step=0.1,
+        value=0,
+        description="omega0",
+        continuous_update=continuous_update,
+    )
     delta_omega1 = FloatSlider(
         min=0,
         max=360,
         description="delta_omega1",
         style={"description_width": "initial"},
+        continuous_update=continuous_update,
     )
     invert = Checkbox(value=False, description="invert")
 
@@ -239,7 +263,8 @@ def makeBundle():
         invert,
         save_box,
     )
-    view.viewer.show()
-    view._was_show_called = True
+    view.show_viewer()
     initialize_bundle()
     update_bundle()
+
+    return view

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -316,7 +316,7 @@ def makeBundle(
     save_button.on_click(save_pdb)
     save_box = HBox([save_button, save_edit])
 
-    view.widget = VBox(
+    view.set_widgets(
         [
             chosen_helix,
             length,

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -126,7 +126,12 @@ def templatePreset(packed_and_poses_and_pdbs=None, *args, **kwargs):
 
 @requires_init
 def makeBundle(
-    modules=[], aa="VAL", num_helices=4, backend="py3Dmol", continuous_update=True
+    modules=[],
+    aa="VAL",
+    num_helices=4,
+    backend="py3Dmol",
+    window_size=None,
+    continuous_update=True,
 ):
     """
     Add a description of the preset Viewer here
@@ -199,6 +204,7 @@ def makeBundle(
     pose = pyrosetta.Pose()
     view = viewer3d.init(
         packed_and_poses_and_pdbs=pose,
+        window_size=window_size,
         modules=modules,
         backend=backend,
     )

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -170,8 +170,8 @@ def makeBundle(
             viewer3d.setStyle(
                 residue_selector=core_selector,
                 cartoon=True,
-                cartoon_color="black",
-                colorscheme="blackCarbon",
+                cartoon_color="red",
+                colorscheme="redCarbon",
                 style="stick",
                 radius=0.25,
                 label=False,
@@ -179,8 +179,8 @@ def makeBundle(
             viewer3d.setStyle(
                 residue_selector=boundary_selector,
                 cartoon=True,
-                cartoon_color="grey",
-                colorscheme="greyCarbon",
+                cartoon_color="orange",
+                colorscheme="orangeCarbon",
                 style="stick",
                 radius=0.25,
                 label=False,
@@ -188,8 +188,8 @@ def makeBundle(
             viewer3d.setStyle(
                 residue_selector=surface_selector,
                 cartoon=True,
-                cartoon_color="white",
-                colorscheme="whiteCarbon",
+                cartoon_color="yellow",
+                colorscheme="yellowCarbon",
                 style="stick",
                 radius=0.25,
                 label=False,

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -159,7 +159,7 @@ def makeBundle(
     )
     from pyrosetta.rosetta.utility import vector1_unsigned_long
 
-    if not modules:
+    if not modules and (backend == "py3Dmol"):
         core_selector = LayerSelector()
         core_selector.set_layers(True, False, False)
         boundary_selector = LayerSelector()
@@ -327,8 +327,6 @@ def makeBundle(
             save_box,
         ]
     )
-    view.show()
-
     initialize_bundle()
     update_bundle()
 


### PR DESCRIPTION
This PR updates the `Py3DmolViewer.show()` and `NGLviewViewer.show()` methods to simply update the models in an existing displayed instance of the viewer without reinitializing the viewer (which would previously clear the cell outputs and display a new viewer object). Here, the viewer object is bound as a class instance attribute so it can get reused by just adding and removing Pose/PDB string models.

This PR also commits a proof-of-concept helical bundle generator preset app, which works with `py3Dmol` and `nglview`.