### PR TITLE
Adding module support for NGLView backend

### DIFF
--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -203,7 +203,7 @@ class PoseBase:
         self.poses[index].append(pose)
         self.pdbstrings[index].append(None)
         if update_viewer:
-            self.update_decoy(index=index)
+            self.update_viewer(index=index)
 
     def add_pdbstring(self, pdbstring, index=None, update_viewer=True):
         if index is None:
@@ -211,7 +211,7 @@ class PoseBase:
         self.poses[index].append(None)
         self.pdbstrings[index].append(pdbstring)
         if update_viewer:
-            self.update_decoy(index=index)
+            self.update_viewer(index=index)
 
     def remove_pose(self, index=None, model=None, update_viewer=True):
         self.remove_pdbstring(index=index, model=model, update_viewer=update_viewer)
@@ -229,7 +229,7 @@ class PoseBase:
                 f"The 'poses' and 'pdbstrings' attributes are empty at index `{index}`."
             )
         if update_viewer:
-            self.update_decoy(index=index)
+            self.update_viewer(index=index)
 
     def update_pose(self, pose, index=None, model=None, update_viewer=True):
         if index is None:
@@ -239,7 +239,7 @@ class PoseBase:
         self.poses[index][model] = pose
         self.pdbstrings[index][model] = None
         if update_viewer:
-            self.update_decoy(index=index)
+            self.update_viewer(index=index)
 
     def update_poses(self, poses, index=None, update_viewer=True):
         if index is None:
@@ -250,7 +250,7 @@ class PoseBase:
         self.poses[index] = poses
         self.pdbstrings[index] = [None] * len(poses)
         if update_viewer:
-            self.update_decoy(index=index)
+            self.update_viewer(index=index)
 
     def update_pdbstrings(self, pdbstrings, index=None, update_viewer=True):
         if index is None:
@@ -261,7 +261,7 @@ class PoseBase:
         self.poses[index] = [None] * len(pdbstrings)
         self.pdbstrings[index] = pdbstrings
         if update_viewer:
-            self.update_decoy(index=index)
+            self.update_viewer(index=index)
 
 
 @attr.s(kw_only=False, slots=False)
@@ -269,7 +269,7 @@ class WidgetsBase:
     decoy_widget = attr.ib(
         default=attr.Factory(
             lambda self: interactive(
-                self.update_decoy,
+                self.update_viewer,
                 index=IntSlider(
                     min=0,
                     max=self.n_decoys - 1,
@@ -291,18 +291,18 @@ class WidgetsBase:
         if self.n_decoys > 1:
             _widgets.insert(0, self.decoy_widget)
         else:
-            self.update_decoy()
+            self.update_viewer()
         return _widgets
 
     def set_widgets(self, obj):
         self.widgets = _to_widgets(obj)
 
-    def update_decoy(self, index=None):
+    def update_viewer(self, index=None):
         time.sleep(self.delay)
         if index is None:
             index = self.get_decoy_widget_index()
         if index in self.poses.keys():
-            self.update_viewer(self.poses[index], self.pdbstrings[index])
+            self.update_objects(self.poses[index], self.pdbstrings[index])
 
 
 @attr.s(kw_only=False, slots=False)

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -81,9 +81,9 @@ class Base3D:
     )
     backend = attr.ib(
         type=str,
-        default=BACKENDS[0],
+        default=None,
         validator=[attr.validators.instance_of(str), attr.validators.in_(BACKENDS)],
-        converter=_to_backend,
+        converter=[attr.converters.default_if_none(default=0), _to_backend],
     )
     auto_show = attr.ib(
         type=bool,
@@ -352,6 +352,9 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
         widgets = self.get_widgets()
         if widgets:
             display(*widgets)
+
+    def set_modules(self, obj):
+        self.modules = ModuleBase._to_modules(obj)
 
     def show(self):
         """Display Viewer in Jupyter notebook."""

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -291,8 +291,10 @@ class WidgetsBase:
     def set_widgets(self, obj):
         self.widgets = _to_widgets(obj)
 
-    def update_decoy(self, index=0):
+    def update_decoy(self, index=None):
         time.sleep(self.delay)
+        if index is None:
+            index = self.get_decoy_widget_index()
         self.update_viewer(self.poses[index], self.pdbstrings[index])
 
 

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -17,7 +17,7 @@ from pyrosetta.rosetta.core.pose import append_pose_to_pose
 from typing import Generic, Iterable, List, Optional, Tuple, TypeVar, Union
 
 from viewer3d.config import _import_backend, BACKENDS
-from viewer3d.converters import _to_float, _to_widgets
+from viewer3d.converters import _to_backend, _to_float, _to_widgets
 from viewer3d.exceptions import ViewerImportError
 from viewer3d.modules import ModuleBase, setZoomTo
 from viewer3d.validators import _validate_int_float, _validate_window_size
@@ -81,9 +81,9 @@ class Base3D:
     )
     backend = attr.ib(
         type=str,
-        default=None,
+        default=BACKENDS[0],
         validator=[attr.validators.instance_of(str), attr.validators.in_(BACKENDS)],
-        converter=attr.converters.default_if_none(default=BACKENDS[0]),
+        converter=_to_backend,
     )
     auto_show = attr.ib(
         type=bool,

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -59,7 +59,7 @@ class Base3D:
         default=None,
         validator=_validate_int_float,
         converter=attr.converters.pipe(
-            attr.converters.default_if_none(0.25), _to_float
+            attr.converters.default_if_none(default=0.0), _to_float
         ),
     )
     continuous_update = attr.ib(
@@ -86,6 +86,12 @@ class Base3D:
         converter=_to_backend,
     )
     auto_show = attr.ib(
+        type=bool,
+        default=None,
+        validator=attr.validators.instance_of(bool),
+        converter=attr.converters.default_if_none(default=False),
+    )
+    gui = attr.ib(
         type=bool,
         default=None,
         validator=attr.validators.instance_of(bool),
@@ -195,7 +201,7 @@ class PoseBase:
         if index is None:
             index = self.get_decoy_widget_index()
         self.poses[index].append(pose)
-        self.pdbstrings[index].append(io.to_pdbstring(pose))
+        self.pdbstrings[index].append(None)
         if update_viewer:
             self.update_decoy(index=index)
 
@@ -231,7 +237,7 @@ class PoseBase:
         if model is None or model not in set(range(len(self.poses[index]))):
             model = 0
         self.poses[index][model] = pose
-        self.pdbstrings[index][model] = io.to_pdbstring(pose)
+        self.pdbstrings[index][model] = None
         if update_viewer:
             self.update_decoy(index=index)
 
@@ -242,7 +248,7 @@ class PoseBase:
         for pose in poses:
             assert isinstance(pose, Pose)
         self.poses[index] = poses
-        self.pdbstrings[index] = list(map(io.to_pdbstring, poses))
+        self.pdbstrings[index] = [None] * len(poses)
         if update_viewer:
             self.update_decoy(index=index)
 
@@ -295,7 +301,8 @@ class WidgetsBase:
         time.sleep(self.delay)
         if index is None:
             index = self.get_decoy_widget_index()
-        self.update_viewer(self.poses[index], self.pdbstrings[index])
+        if index in self.poses.keys():
+            self.update_viewer(self.poses[index], self.pdbstrings[index])
 
 
 @attr.s(kw_only=False, slots=False)

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -317,7 +317,11 @@ class WidgetsBase:
         return _widgets
 
     def get_widgets_dict(self):
-        return {widget.description: widget.value for widget in self.widgets}
+        return {
+            widget.description: widget.value
+            for widget in self.widgets
+            if all(hasattr(widget, attr) for attr in ("description", "value"))
+        }
 
     def set_widgets(self, obj):
         self.widgets = _to_widgets(obj)

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -304,6 +304,12 @@ class WidgetsBase:
         if index in self.poses.keys():
             self.update_objects(self.poses[index], self.pdbstrings[index])
 
+    def _maybe_enable_custom_widget_manager():
+        if "google.colab" in sys.modules:
+            from google.colab import output
+
+            output.enable_custom_widget_manager()
+
 
 @attr.s(kw_only=False, slots=False)
 class ViewerBase(Base3D, PoseBase, WidgetsBase):
@@ -311,6 +317,7 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
 
     def __attrs_post_init__(self):
         self.setup()
+        self._maybe_enable_custom_widget_manager()
         if self.auto_show:
             self.show()
 

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -270,27 +270,29 @@ class WidgetsBase:
         ),
     )
 
-    def update_decoy(self, index=0):
-        time.sleep(self.delay)
-        self.update_viewer(self.poses[index], self.pdbstrings[index])
-
-    def set_widgets(self, obj):
-        self.widgets = _to_widgets(obj)
-
-    def get_widgets(self):
-        _widgets = self.widgets.copy()
-        if self.n_decoys > 1:
-            _widgets.insert(0, self.decoy_widget)
-        return _widgets
-
-
-@attr.s(kw_only=False, slots=False)
-class ViewerBase(Base3D, PoseBase, WidgetsBase):
     def get_decoy_widget_index(self):
         kwargs = self.decoy_widget.kwargs
         index = kwargs["index"] if kwargs else 0
         return index
 
+    def get_widgets(self):
+        _widgets = self.widgets.copy()
+        if self.n_decoys > 1:
+            _widgets.insert(0, self.decoy_widget)
+        else:
+            self.update_decoy()
+        return _widgets
+
+    def set_widgets(self, obj):
+        self.widgets = _to_widgets(obj)
+
+    def update_decoy(self, index=0):
+        time.sleep(self.delay)
+        self.update_viewer(self.poses[index], self.pdbstrings[index])
+
+
+@attr.s(kw_only=False, slots=False)
+class ViewerBase(Base3D, PoseBase, WidgetsBase):
     def __attrs_post_init__(self):
         self.setup()
         if self.auto_show:
@@ -316,7 +318,9 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
         self.add_objects(_poses, _pdbstrings)
 
     def display_widgets(self):
-        display(*self.get_widgets())
+        widgets = self.get_widgets()
+        if widgets:
+            display(*widgets)
 
     def show(self):
         """Display Viewer in Jupyter notebook."""

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -316,6 +316,9 @@ class WidgetsBase:
             self.update_viewer()
         return _widgets
 
+    def get_widgets_dict(self):
+        return {widget.description: widget.value for widget in self.widgets}
+
     def set_widgets(self, obj):
         self.widgets = _to_widgets(obj)
 

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -189,6 +189,14 @@ class Base3D:
         """Subtract all modules from the Viewer instance."""
         self.modules = []
 
+    def clear_modules(self):
+        """Subtract all modules from the Viewer instance."""
+        self.modules = []
+
+    def clear(self):
+        """Alias of the `clear_modules` method."""
+        self.clear_modules()
+
     def reset(self):
         """Delete Viewer instance attributes."""
         self.poses = None

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -186,7 +186,7 @@ class Base3D:
 
 @attr.s(kw_only=False, slots=False)
 class PoseBase:
-    def add_pose(self, pose=None, index=None, update_viewer=True):
+    def add_pose(self, pose, index=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
         self.poses[index].append(pose)
@@ -194,7 +194,7 @@ class PoseBase:
         if update_viewer:
             self.update_decoy(index=index)
 
-    def add_pdbstring(self, pdbstring=None, index=None, update_viewer=True):
+    def add_pdbstring(self, pdbstring, index=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
         self.poses[index].append(None)
@@ -220,7 +220,7 @@ class PoseBase:
         if update_viewer:
             self.update_decoy(index=index)
 
-    def update_pose(self, pose=None, index=None, model=None, update_viewer=True):
+    def update_pose(self, pose, index=None, model=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
         if model is None or model not in set(range(len(self.poses[index]))):
@@ -230,7 +230,7 @@ class PoseBase:
         if update_viewer:
             self.update_decoy(index=index)
 
-    def update_poses(self, poses=None, index=None, update_viewer=True):
+    def update_poses(self, poses, index=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
         assert isinstance(poses, list)
@@ -241,7 +241,7 @@ class PoseBase:
         if update_viewer:
             self.update_decoy(index=index)
 
-    def update_pdbstrings(self, pdbstrings=None, index=None, update_viewer=True):
+    def update_pdbstrings(self, pdbstrings, index=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
         assert isinstance(pdbstrings, list)
@@ -255,34 +255,6 @@ class PoseBase:
 
 @attr.s(kw_only=False, slots=False)
 class WidgetsBase:
-    pass
-    # decoy_widget = attr.ib(
-    #     default=attr.Factory(
-    #         lambda self: interactive(
-    #             self.update_decoy,
-    #             index=IntSlider(
-    #                 min=0,
-    #                 max=self.n_decoys - 1,
-    #                 description="Decoys",
-    #                 continuous_update=self.continuous_update,
-    #             ),
-    #         ),
-    #         takes_self=True,
-    #     )
-    # )
-
-    # def set_widgets(self, obj):
-    #     self.widgets = _to_widgets(obj)
-    #
-    # def get_widgets(self):
-    #     _widgets = self.widgets.copy()
-    #     if self.n_decoys > 1:
-    #         _widgets.insert(0, self.decoy_widget)
-    #     return _widgets
-
-
-@attr.s(kw_only=False, slots=False)
-class ViewerBase(Base3D, PoseBase, WidgetsBase):
     decoy_widget = attr.ib(
         default=attr.Factory(
             lambda self: interactive(
@@ -298,6 +270,10 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
         ),
     )
 
+    def update_decoy(self, index=0):
+        time.sleep(self.delay)
+        self.update_viewer(self.poses[index], self.pdbstrings[index])
+
     def set_widgets(self, obj):
         self.widgets = _to_widgets(obj)
 
@@ -307,10 +283,9 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
             _widgets.insert(0, self.decoy_widget)
         return _widgets
 
-    def update_decoy(self, index=0):
-        time.sleep(self.delay)
-        self.update_viewer(self.poses[index], self.pdbstrings[index])
 
+@attr.s(kw_only=False, slots=False)
+class ViewerBase(Base3D, PoseBase, WidgetsBase):
     def get_decoy_widget_index(self):
         kwargs = self.decoy_widget.kwargs
         index = kwargs["index"] if kwargs else 0
@@ -323,7 +298,6 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
 
     @silence_tracer
     def apply_modules(self, _pose, _pdbstring, _model):
-        # for _model in range(len(_poses)):
         for _module in self.modules:
             func = getattr(_module, f"apply_{self.backend}")
             self.viewer = func(
@@ -340,7 +314,6 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
             _pdbstrings
         ), "Number of `Pose` objects and PDB `str` objects must be equal."
         self.add_objects(_poses, _pdbstrings)
-        # self.apply_modules(_poses, _pdbstrings)
 
     def display_widgets(self):
         display(*self.get_widgets())
@@ -352,7 +325,6 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
             self._toggle_window(self.window_size)
             self.display_widgets()
             self.show_viewer()
-            # self.update_decoy(index=self.get_decoy_widget_index())
 
 
 def expand_notebook():

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -304,7 +304,7 @@ class WidgetsBase:
         if index in self.poses.keys():
             self.update_objects(self.poses[index], self.pdbstrings[index])
 
-    def _maybe_setup_colab():
+    def _maybe_setup_colab(self):
         if "google.colab" in sys.modules:
             sys.modules["google.colab"].output.enable_custom_widget_manager()
 

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -20,7 +20,6 @@ from viewer3d.config import _import_backend, BACKENDS
 from viewer3d.converters import _to_float, _to_widgets
 from viewer3d.exceptions import ViewerImportError
 from viewer3d.modules import ModuleBase
-from viewer3d.tracer import silence_tracer
 from viewer3d.validators import _validate_int_float, _validate_window_size
 
 
@@ -298,7 +297,6 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
         if self.auto_show:
             self.show()
 
-    @silence_tracer
     def apply_modules(self, _pose, _pdbstring, _model):
         for _module in self.modules:
             func = getattr(_module, f"apply_{self.backend}")
@@ -325,10 +323,11 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
     def show(self):
         """Display Viewer in Jupyter notebook."""
         if self._in_notebook():
-            self._toggle_scrolling()
+            self._clear_output()
             self._toggle_window(self.window_size)
             self.display_widgets()
             self.show_viewer()
+            self._toggle_scrolling()
 
 
 def expand_notebook():

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -20,7 +20,11 @@ from viewer3d.config import _import_backend, BACKENDS
 from viewer3d.converters import _to_backend, _to_float, _to_widgets
 from viewer3d.exceptions import ViewerImportError
 from viewer3d.modules import ModuleBase, setZoomTo
-from viewer3d.validators import _validate_int_float, _validate_window_size
+from viewer3d.validators import (
+    _validate_int_float,
+    _validate_window_size,
+    requires_show,
+)
 
 
 _logger = logging.getLogger("viewer3d.base")
@@ -197,6 +201,7 @@ class Base3D:
 
 @attr.s(kw_only=False, slots=False)
 class PoseBase:
+    @requires_show
     def add_pose(self, pose, index=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
@@ -206,6 +211,7 @@ class PoseBase:
             model = len(self.poses[index]) - 1
             self.add_objects(self.poses[index], self.pdbstrings[index], _model=model)
 
+    @requires_show
     def add_pdbstring(self, pdbstring, index=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
@@ -215,9 +221,11 @@ class PoseBase:
             model = len(self.poses[index]) - 1
             self.add_objects(self.poses[index], self.pdbstrings[index], _model=model)
 
+    @requires_show
     def remove_pose(self, index=None, model=None, update_viewer=True):
         self.remove_pdbstring(index=index, model=model, update_viewer=update_viewer)
 
+    @requires_show
     def remove_pdbstring(self, index=None, model=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
@@ -233,6 +241,7 @@ class PoseBase:
         if update_viewer:
             self.remove_objects(model)
 
+    @requires_show
     def update_pose(self, pose, index=None, model=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
@@ -248,6 +257,7 @@ class PoseBase:
         if update_viewer:
             self.update_objects(self.poses[index], self.pdbstrings[index], _model=model)
 
+    @requires_show
     def update_pdbstring(self, pdbstring, index=None, model=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
@@ -263,23 +273,31 @@ class PoseBase:
         if update_viewer:
             self.update_objects(self.poses[index], self.pdbstrings[index], _model=model)
 
+    @requires_show
     def update_poses(self, poses, index=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
-        assert isinstance(poses, list)
+        assert isinstance(poses, list), "The 'poses' argument must be of type `list`."
         for pose in poses:
-            assert isinstance(pose, Pose)
+            assert isinstance(
+                pose, Pose
+            ), f"Object must be of type `Pose`. Received: {type(pose)}"
         self.poses[index] = poses
         self.pdbstrings[index] = [None] * len(poses)
         if update_viewer:
             self.update_viewer(index=index)
 
+    @requires_show
     def update_pdbstrings(self, pdbstrings, index=None, update_viewer=True):
         if index is None:
             index = self.get_decoy_widget_index()
-        assert isinstance(pdbstrings, list)
+        assert isinstance(
+            pdbstrings, list
+        ), "The 'pdbstrings' argument must be of type `list`."
         for pdbstring in pdbstrings:
-            assert isinstance(pdbstring, str)
+            assert isinstance(
+                pdbstring, str
+            ), f"Object must be of type `str`. Received: {type(pdbstring)}"
         self.poses[index] = [None] * len(pdbstrings)
         self.pdbstrings[index] = pdbstrings
         if update_viewer:

--- a/viewer3d/base.py
+++ b/viewer3d/base.py
@@ -304,11 +304,9 @@ class WidgetsBase:
         if index in self.poses.keys():
             self.update_objects(self.poses[index], self.pdbstrings[index])
 
-    def _maybe_enable_custom_widget_manager():
+    def _maybe_setup_colab():
         if "google.colab" in sys.modules:
-            from google.colab import output
-
-            output.enable_custom_widget_manager()
+            sys.modules["google.colab"].output.enable_custom_widget_manager()
 
 
 @attr.s(kw_only=False, slots=False)
@@ -317,7 +315,7 @@ class ViewerBase(Base3D, PoseBase, WidgetsBase):
 
     def __attrs_post_init__(self):
         self.setup()
-        self._maybe_enable_custom_widget_manager()
+        self._maybe_setup_colab()
         if self.auto_show:
             self.show()
 

--- a/viewer3d/converters.py
+++ b/viewer3d/converters.py
@@ -15,6 +15,7 @@ from pyrosetta.rosetta.core.pose.full_model_info import (
 from pyrosetta.rosetta.core.select import get_residues_from_subset
 from typing import List
 
+from viewer3d.config import BACKENDS
 from viewer3d.exceptions import ViewerInputError
 
 
@@ -98,6 +99,18 @@ def _to_0_if_le_0(obj):
 
 def _to_1_if_gt_1(obj):
     return 1 if isinstance(obj, (float, int)) and obj > 1 else obj
+
+
+def _to_backend(obj):
+    if isinstance(obj, int):
+        try:
+            backend = BACKENDS[obj]
+        except IndexError:
+            raise IndexError(f"Backend index doesn't exist in: `{BACKENDS}`.")
+    else:
+        backend = obj
+
+    return backend
 
 
 def _to_widgets(objs) -> List[Widget]:

--- a/viewer3d/converters.py
+++ b/viewer3d/converters.py
@@ -115,7 +115,7 @@ def _to_1_if_gt_1(obj):
     return 1 if isinstance(obj, (float, int)) and obj > 1 else obj
 
 
-def _to_backend(obj):
+def _to_backend(obj) -> str:
     if isinstance(obj, int):
         try:
             backend = BACKENDS[obj]

--- a/viewer3d/converters.py
+++ b/viewer3d/converters.py
@@ -48,6 +48,12 @@ def _to_poses_pdbstrings(packed_and_poses_and_pdbs):
             with open(obj, "r") as f:
                 return f.read()
 
+    def to_dict(objs):
+        d = collections.defaultdict(list)
+        for i, obj in enumerate(objs):
+            d[i].append(obj)
+        return collections.OrderedDict(d)
+
     if isinstance(
         packed_and_poses_and_pdbs, collections.abc.Iterable
     ) and not isinstance(packed_and_poses_and_pdbs, (Pose, PackedPose)):
@@ -58,6 +64,9 @@ def _to_poses_pdbstrings(packed_and_poses_and_pdbs):
     else:
         poses = [to_pose(packed_and_poses_and_pdbs)]
         pdbstrings = [to_pdbstring(packed_and_poses_and_pdbs)]
+
+    poses = to_dict(poses)
+    pdbstrings = to_dict(pdbstrings)
 
     return poses, pdbstrings
 

--- a/viewer3d/converters.py
+++ b/viewer3d/converters.py
@@ -143,6 +143,12 @@ def _pose_to_residue_chain_tuples(pose, residue_selector, logger=_logger):
         return map(list, zip(*residue_chain_tuples))
 
 
+def _get_nglview_selection(pose, residue_selector, logger=_logger) -> str:
+    resi, chain = _pose_to_residue_chain_tuples(pose, residue_selector, logger=_logger)
+    selection = " or ".join(map(lambda rc: f"({rc[0]}:{rc[1]})", zip(resi, chain)))
+    return selection
+
+
 def _pdbstring_to_pose(pdbstring, class_name, logger=_logger):
     """Convert pdbstring to a `Pose` with logging."""
     logger.info(

--- a/viewer3d/converters.py
+++ b/viewer3d/converters.py
@@ -164,3 +164,8 @@ def _pdbstring_to_pose(pdbstring, class_name, logger=_logger):
         )
     )
     return io.to_pose(io.pose_from_pdbstring(pdbstring))
+
+
+def _get_residue_chain_tuple(pose, res):
+    residue, chain = map(lambda x: x.strip(), pose.pdb_info().pose2pdb(res).split())
+    return residue, chain

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -205,8 +205,6 @@ def init(
     -------
     A Viewer instance.
     """
-    # if not pyrosetta.rosetta.basic.was_init_called():
-    #     pyrosetta.init(options="-out:level 100")
     viewer = SetupViewer(
         packed_and_poses_and_pdbs=packed_and_poses_and_pdbs,
         window_size=window_size,

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -83,7 +83,7 @@ class NGLviewViewer(ViewerBase):
         self.update_objects(_poses, _pdbstrings)
 
     def show_viewer(self):
-        self.viewer.display(gui=True, style="ngl")
+        self.viewer.display(gui=self.gui, style="ngl")
         self.viewer._remote_call(
             "setSize",
             targe="Widget",
@@ -119,7 +119,7 @@ class PyMOLViewer(ViewerBase):
 @attr.s(kw_only=True, slots=False, frozen=False)
 class SetupViewer(Base3D):
     packed_and_poses_and_pdbs = attr.ib(
-        type=Union[PackedPose, Pose, Iterable[Union[PackedPose, Pose]], None],
+        type=Optional[Union[PackedPose, Pose, Iterable[Union[PackedPose, Pose]]]],
         default=None,
     )
 
@@ -137,11 +137,14 @@ class SetupViewer(Base3D):
             continuous_update=self.continuous_update,
             widgets=self.widgets,
             backend=self.backend,
+            gui=self.gui,
             n_decoys=self.n_decoys,
         )
 
     def initialize_viewer(self):
         if self.backend == BACKENDS[0]:
+            if self.gui:
+                _logger.debug(f"GUI is not supported for `{self.backend}` backend.")
             viewer = Py3DmolViewer(**self.viewer_kwargs)
         elif self.backend == BACKENDS[1]:
             viewer = NGLviewViewer(**self.viewer_kwargs)
@@ -158,6 +161,7 @@ def init(
     delay=None,
     continuous_update=None,
     backend=None,
+    gui=None,
     auto_show=None,
 ):
     """
@@ -214,6 +218,7 @@ def init(
         delay=delay,
         continuous_update=continuous_update,
         backend=backend,
+        gui=gui,
         auto_show=auto_show,
     ).initialize_viewer()
 

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -33,10 +33,10 @@ class Py3DmolViewer(ViewerBase):
                 _pdbstring = io.to_pdbstring(_pose)
             else:
                 _pdbstring = _pdbstrings[_model]
-            self.viewer.addModels(_pdbstring, "pdb", _model)
+            self.viewer.addModel(_pdbstring, "pdb")
             self.apply_modules(_pose, _pdbstring, _model)
-        if self._displayed:
-            self.viewer.update()
+            if self._displayed:
+                self.viewer.update()
 
     def remove_objects(self):
         self.viewer.removeAllLabels()
@@ -67,7 +67,9 @@ class NGLviewViewer(ViewerBase):
             self.viewer._ngl_component_ids.append(structure.id)
             self.viewer._update_component_auto_completion()
         for _model in _model_range:
-            self.apply_modules(_poses[_model], _pdbstrings[_model], _model)
+            _pose = _poses[_model]
+            _pdbstring = _pdbstrings[_model]
+            self.apply_modules(_pose, _pdbstring, _model)
 
     def remove_objects(self):
         component_ids = self.viewer._ngl_component_ids

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -28,11 +28,17 @@ class Py3DmolViewer(ViewerBase):
             height=self.window_size[1],
         )
 
-    def add_objects(self, _pose=None, _pdbstring=None):
-        if _pose is not None:
-            self.viewer.addModels(io.to_pdbstring(_pose), "pdb")
-        else:
-            self.viewer.addModels(_pdbstring, "pdb")
+    def add_objects(self, _poses, _pdbstrings):
+        for _model in range(len(_poses)):
+            _pose = _poses[_model]
+            if _pose is not None:
+                _pdbstring = io.to_pdbstring(_pose)
+            else:
+                _pdbstring = _pdbstrings[_model]
+            self.viewer.addModels(_pdbstring, "pdb", _model)
+            # self.viewer.update()
+            self.apply_modules(_pose, _pdbstring, _model)
+            self.viewer.update()
 
     def remove_objects(self):
         self.viewer.removeAllLabels()
@@ -40,10 +46,11 @@ class Py3DmolViewer(ViewerBase):
         self.viewer.removeAllShapes()
         self.viewer.removeAllSurfaces()
 
-    def update_viewer(self, _pose=None, _pdbstring=None):
-        self.update_objects(_pose=_pose, _pdbstring=_pose)
-        if self._displayed:
-            self.viewer.update()
+    def update_viewer(self, _poses, _pdbstrings):
+        self.update_objects(_poses, _pdbstrings)
+        # if self._displayed:
+        # print("HERE")
+        # self.viewer.update()
 
     def show_viewer(self):
         self.viewer.show()
@@ -56,7 +63,7 @@ class NGLviewViewer(ViewerBase):
         self.nglview = self._maybe_import_backend()
         self.viewer = self.nglview.widget.NGLWidget()
 
-    def add_objects(self, _pose=None, _pdbstring=None):
+    def add_objects(self, _pose, _pdbstring):
         if _pose is not None:
             structure = self.nglview.adaptor.RosettaStructure(_pose)
         else:
@@ -67,7 +74,7 @@ class NGLviewViewer(ViewerBase):
         for component_id in self.viewer._ngl_component_ids:
             self.viewer.remove_component(component_id)
 
-    def update_viewer(self, _pose=None, _pdbstring=None):
+    def update_viewer(self, _pose, _pdbstring):
         self.update_objects(_pose=_pose, _pdbstring=_pdbstring)
 
     def show_viewer(self):
@@ -141,6 +148,7 @@ def init(
     delay=None,
     continuous_update=None,
     backend=None,
+    auto_show=None,
 ):
     """
     Initialize the Viewer object.
@@ -196,6 +204,7 @@ def init(
         delay=delay,
         continuous_update=continuous_update,
         backend=backend,
+        auto_show=auto_show,
     ).initialize_viewer()
 
     return viewer

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -205,6 +205,8 @@ def init(
     -------
     A Viewer instance.
     """
+    # if not pyrosetta.rosetta.basic.was_init_called():
+    #     pyrosetta.init(options="-out:level 100")
     viewer = SetupViewer(
         packed_and_poses_and_pdbs=packed_and_poses_and_pdbs,
         window_size=window_size,

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -65,6 +65,14 @@ class NGLviewViewer(ViewerBase):
         self.nglview = self._maybe_import_backend()
         self.viewer = self.nglview.widget.NGLWidget()
 
+    def set_window_size(self):
+        """Resize the NGLWidget window."""
+        self.viewer._remote_call(
+            "setSize",
+            targe="Widget",
+            args=[f"{self.window_size[0]}px", f"{self.window_size[1]}px"],
+        )
+
     def add_object(self, _poses, _pdbstrings, _model):
         _pose = _poses[_model]
         if _pose is not None:
@@ -104,11 +112,7 @@ class NGLviewViewer(ViewerBase):
 
     def show_viewer(self):
         self.viewer.display(gui=self.gui, style="ngl")
-        self.viewer._remote_call(
-            "setSize",
-            targe="Widget",
-            args=[f"{self.window_size[0]}px", f"{self.window_size[1]}px"],
-        )  # Resize NGLWidget window
+        self.set_window_size()
         self.viewer._ipython_display_()
 
 

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -19,8 +19,6 @@ _logger = logging.getLogger("viewer3d.core")
 
 @attr.s(kw_only=True, slots=False)
 class Py3DmolViewer(ViewerBase):
-    _displayed = attr.ib(type=bool, default=False, init=False)
-
     def setup(self):
         self.py3Dmol = self._maybe_import_backend()
         self.viewer = self.py3Dmol.view(
@@ -51,7 +49,6 @@ class Py3DmolViewer(ViewerBase):
 
     def show_viewer(self):
         self.viewer.show()
-        self._displayed = True
 
 
 @attr.s(kw_only=True, slots=False)
@@ -87,6 +84,11 @@ class NGLviewViewer(ViewerBase):
 
     def show_viewer(self):
         self.viewer.display(gui=True, style="ngl")
+        self.viewer._remote_call(
+            "setSize",
+            targe="Widget",
+            args=[f"{self.window_size[0]}px", f"{self.window_size[1]}px"],
+        )  # Resize NGLWidget window
         self.viewer._ipython_display_()
 
 

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -35,17 +35,14 @@ class Py3DmolViewer(ViewerBase):
                 _pdbstring = _pdbstrings[_model]
             self.viewer.addModels(_pdbstring, "pdb", _model)
             self.apply_modules(_pose, _pdbstring, _model)
+        if self._displayed:
+            self.viewer.update()
 
     def remove_objects(self):
         self.viewer.removeAllLabels()
         self.viewer.removeAllModels()
         self.viewer.removeAllShapes()
         self.viewer.removeAllSurfaces()
-
-    def update_viewer(self, _poses, _pdbstrings):
-        self.update_objects(_poses, _pdbstrings)
-        if self._displayed:
-            self.viewer.update()
 
     def show_viewer(self):
         self.viewer.show()
@@ -78,9 +75,6 @@ class NGLviewViewer(ViewerBase):
             component_index = component_ids.index(component_id)
             self.viewer.remove_component(component_id)
             self.viewer.clear(component=component_index)
-
-    def update_viewer(self, _poses, _pdbstrings):
-        self.update_objects(_poses, _pdbstrings)
 
     def show_viewer(self):
         self.viewer.display(gui=self.gui, style="ngl")

--- a/viewer3d/core.py
+++ b/viewer3d/core.py
@@ -61,17 +61,19 @@ class NGLviewViewer(ViewerBase):
         self.viewer = self.nglview.widget.NGLWidget()
 
     def add_objects(self, _poses, _pdbstrings):
-        for _model in range(len(_poses)):
+        _model_range = range(len(_poses))
+        for _model in _model_range:
             _pose = _poses[_model]
-            _pdbstring = _pdbstrings[_model]
             if _pose is not None:
                 structure = self.nglview.adaptor.RosettaStructure(_pose)
             else:
+                _pdbstring = _pdbstrings[_model]
                 structure = self.nglview.adaptor.TextStructure(_pdbstring, ext="pdb")
             self.viewer._load_data(structure)
             self.viewer._ngl_component_ids.append(structure.id)
             self.viewer._update_component_auto_completion()
-            self.apply_modules(_pose, _pdbstring, _model)
+        for _model in _model_range:
+            self.apply_modules(_poses[_model], _pdbstrings[_model], _model)
 
     def remove_objects(self):
         component_ids = self.viewer._ngl_component_ids

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -952,7 +952,7 @@ class setSurface(ModuleBase):
     colorscheme = attr.ib(
         default=None,
         type=Optional[Union[str, int]],
-        validator=attr.validators.instance_of(attr.validators.instance_of((str, int))),
+        validator=attr.validators.optional(attr.validators.instance_of((str, int))),
     )
 
     @requires_init

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -1005,6 +1005,8 @@ class setSurface(ModuleBase):
                 component=model,
             )
 
+        return viewer
+
     def apply_pymol(self):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[2])
 

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -753,8 +753,11 @@ class setStyle(ModuleBase):
         # Set defaults
         if self.cartoon_color is None:
             self.cartoon_color = "atomindex"
-        if self.colorscheme == "blackCarbon":
-            self.colorscheme = "element"
+        if self.colorscheme.endswith("Carbon"):
+            if self.colorscheme == "blackCarbon":
+                self.colorscheme = "element"
+            else:
+                self.colorscheme = self.colorscheme.replace("Carbon", "")
         if self.style == "stick":
             self.style = "licorice"
         elif self.style == "sphere":

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -794,13 +794,14 @@ class setStyle(ModuleBase):
             if not selection:
                 pass
             else:
-                viewer.add_representation(
-                    repr_type=self.style,
-                    selection=selection_hydrogens,
-                    color=self.colorscheme,
-                    radius=self.radius,
-                    component=model,
-                )
+                if self.radius > 1e-10:
+                    viewer.add_representation(
+                        repr_type=self.style,
+                        selection=selection_hydrogens,
+                        color=self.colorscheme,
+                        radius=self.radius,
+                        component=model,
+                    )
                 if self.cartoon:
                     viewer.remove_cartoon(component=model)
                     viewer.add_representation(
@@ -823,13 +824,14 @@ class setStyle(ModuleBase):
                         component=model,
                     )
         else:
-            viewer.add_representation(
-                repr_type=self.style,
-                selection=default_selection,
-                color=self.colorscheme,
-                radius=self.radius,
-                component=model,
-            )
+            if self.radius > 1e-10:
+                viewer.add_representation(
+                    repr_type=self.style,
+                    selection=default_selection,
+                    color=self.colorscheme,
+                    radius=self.radius,
+                    component=model,
+                )
             if self.cartoon:
                 viewer.remove_cartoon(component=model)
                 viewer.add_representation(

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -2,7 +2,6 @@ import attr
 import itertools
 import logging
 import pyrosetta
-import pyrosetta.distributed
 import pyrosetta.distributed.io as io
 import sys
 
@@ -24,6 +23,7 @@ from viewer3d.converters import (
     _to_1_if_gt_1,
 )
 from viewer3d.exceptions import ModuleNotImplementedError
+from viewer3d.tracer import requires_init
 
 
 _logger = logging.getLogger("viewer3d.modules")
@@ -111,7 +111,7 @@ class setDisulfides(ModuleBase):
         converter=attr.converters.default_if_none(default=0.25),
     )
 
-    @pyrosetta.distributed.requires_init
+    @requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
@@ -134,6 +134,7 @@ class setDisulfides(ModuleBase):
 
         return viewer
 
+    @requires_init
     def apply_nglview(self, viewer, pose, pdbstring, model):
         cys_res = [i for i, aa in enumerate(pose.sequence(), start=1) if aa == "C"]
         selection_disulfides = []
@@ -149,15 +150,6 @@ class setDisulfides(ModuleBase):
                     radius=self.radius,
                     component=model,
                 )
-                # selection_disulfides.append(sele)
-        # selection = " or ".join(selection_disulfides)
-        # viewer.add_representation(
-        #     repr_type="distance",
-        #     selection=selection,
-        #     color=self.color,
-        #     # radius=self.radius,
-        #     component=model,
-        # )
 
         return viewer
 
@@ -218,7 +210,7 @@ class setHydrogenBonds(ModuleBase):
         converter=_to_0_if_le_0,
     )
 
-    @pyrosetta.distributed.requires_init
+    @requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
@@ -277,6 +269,7 @@ class setHydrogenBonds(ModuleBase):
 
         return viewer
 
+    @requires_init
     def apply_nglview(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
@@ -402,7 +395,7 @@ class setHydrogens(ModuleBase):
         )
         return _viewer
 
-    @pyrosetta.distributed.requires_init
+    @requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
@@ -434,6 +427,7 @@ class setHydrogens(ModuleBase):
 
         return viewer
 
+    @requires_init
     def apply_nglview(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
@@ -667,7 +661,7 @@ class setStyle(ModuleBase):
         converter=attr.converters.default_if_none(default=False),
     )
 
-    @pyrosetta.distributed.requires_init
+    @requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if self.show_hydrogens:
             _logger.warning(
@@ -749,7 +743,7 @@ class setStyle(ModuleBase):
 
         return viewer
 
-    @pyrosetta.distributed.requires_init
+    @requires_init
     def apply_nglview(self, viewer, pose, pdbstring, model):
         # Set defaults
         if self.cartoon_color is None:
@@ -927,7 +921,7 @@ class setSurface(ModuleBase):
         validator=attr.validators.instance_of((str, type(None))),
     )
 
-    @pyrosetta.distributed.requires_init
+    @requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         py3Dmol = sys.modules["py3Dmol"]
         surface_types_dict: Dict[str, int] = {
@@ -1033,7 +1027,7 @@ class setZoomTo(ModuleBase):
         converter=attr.converters.default_if_none(default=TrueResidueSelector()),
     )
 
-    @pyrosetta.distributed.requires_init
+    @requires_init
     def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
@@ -1047,6 +1041,7 @@ class setZoomTo(ModuleBase):
 
         return viewer
 
+    @requires_init
     def apply_nglview(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -553,8 +553,8 @@ class setStyle(ModuleBase):
                 else:
                     if self.cartoon:
                         viewer.setStyle(
-                            {"model": model},
-                            {"resi": resi, "chain": chain},
+                            # {"model": model},
+                            {"model": model, "resi": resi, "chain": chain},
                             {
                                 "cartoon": {"color": self.cartoon_color},
                                 self.style: {
@@ -565,8 +565,8 @@ class setStyle(ModuleBase):
                         )
                     else:
                         viewer.setStyle(
-                            {"model": model},
-                            {"resi": resi, "chain": chain},
+                            # {"model": model},
+                            {"model": model, "resi": resi, "chain": chain},
                             {
                                 self.style: {
                                     "colorscheme": self.colorscheme,
@@ -576,8 +576,8 @@ class setStyle(ModuleBase):
                         )
                     if self.label:
                         viewer.addResLabels(
-                            {"model": model},
-                            {"resi": resi, "chain": chain},
+                            # {"model": model},
+                            {"model": model, "resi": resi, "chain": chain},
                             {
                                 "fontSize": self.label_fontsize,
                                 "showBackground": self.label_background,

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -157,20 +157,23 @@ class setDisulfides(ModuleBase):
                 i_sele = f"{i_res}:{i_chain}.{self.sulfur_atom_name}"
                 j_sele = f"{j_res}:{j_chain}.{self.sulfur_atom_name}"
                 selection_disulfides.append([i_sele, j_sele])
-        selection = " or ".join([f"({s[0]} or {s[1]})" for s in selection_disulfides])
-        viewer.add_representation(
-            repr_type="ball+stick",
-            selection=selection,
-            color=self.color,
-            radius=self.radius,
-            component=model,
-        )
-        viewer.add_distance(
-            atom_pair=selection_disulfides,
-            color=self.color,
-            radius=self.radius,
-            label_visible=False,
-        )
+        if selection_disulfides:
+            viewer.add_distance(
+                atom_pair=selection_disulfides,
+                color=self.color,
+                radius=self.radius,
+                label_visible=False,
+            )
+            selection = " or ".join(
+                [f"({s[0]} or {s[1]})" for s in selection_disulfides]
+            )
+            viewer.add_representation(
+                repr_type="ball+stick",
+                selection=selection,
+                color=self.color,
+                radius=self.radius,
+                component=model,
+            )
 
         return viewer
 

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -1013,7 +1013,8 @@ class setSurface(ModuleBase):
 class setZoom(ModuleBase):
     """
     Set the zoom magnification factor of each initialized `.pdb` file, `Pose` or `PackedPose` object.
-    Values >1 zoom in, and values <1 zoom out.
+    For the `py3Dmol` backend, values >1 zoom in, and values <1 zoom out.
+    For the `nglview` backend, values >0 zoom in, and values <0 zoom out.
 
     Parameters
     ----------
@@ -1039,7 +1040,8 @@ class setZoom(ModuleBase):
         return viewer
 
     def apply_nglview(self, viewer, pose, pdbstring, model):
-        raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
+        viewer.control.zoom(self.factor)
+        return viewer
 
     def apply_pymol(self):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[2])

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -54,12 +54,12 @@ class setBackgroundColor(ModuleBase):
         converter=attr.converters.default_if_none(default=0xFFFFFFFF),
     )
 
-    def apply_py3Dmol(self, viewer, pose, pdbstring):
+    def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         viewer.setBackgroundColor(self.color)
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring):
+    def apply_nglview(self, viewer, pose, pdbstring, model):
         viewer.background = self.color
 
         return viewer
@@ -107,7 +107,7 @@ class setDisulfides(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring):
+    def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -143,7 +143,7 @@ class setDisulfides(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring):
+    def apply_nglview(self, viewer, pose, pdbstring, model):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -204,7 +204,7 @@ class setHydrogenBonds(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring):
+    def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -262,7 +262,7 @@ class setHydrogenBonds(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring):
+    def apply_nglview(self, viewer, pose, pdbstring, model):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -332,7 +332,7 @@ class setHydrogens(ModuleBase):
         return _viewer
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring):
+    def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -357,7 +357,7 @@ class setHydrogens(ModuleBase):
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring):
+    def apply_nglview(self, viewer, pose, pdbstring, model):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -535,7 +535,7 @@ class setStyle(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring):
+    def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if self.command:
             if isinstance(self.command, tuple):
                 viewer.setStyle(*self.command)
@@ -553,6 +553,7 @@ class setStyle(ModuleBase):
                 else:
                     if self.cartoon:
                         viewer.setStyle(
+                            {"model": model},
                             {"resi": resi, "chain": chain},
                             {
                                 "cartoon": {"color": self.cartoon_color},
@@ -564,6 +565,7 @@ class setStyle(ModuleBase):
                         )
                     else:
                         viewer.setStyle(
+                            {"model": model},
                             {"resi": resi, "chain": chain},
                             {
                                 self.style: {
@@ -574,6 +576,7 @@ class setStyle(ModuleBase):
                         )
                     if self.label:
                         viewer.addResLabels(
+                            {"model": model},
                             {"resi": resi, "chain": chain},
                             {
                                 "fontSize": self.label_fontsize,
@@ -584,28 +587,30 @@ class setStyle(ModuleBase):
             else:
                 if self.cartoon:
                     viewer.setStyle(
+                        {"model": model},
                         {
                             "cartoon": {"color": self.cartoon_color},
                             self.style: {
                                 "colorscheme": self.colorscheme,
                                 "radius": self.radius,
                             },
-                        }
+                        },
                     )
                 else:
                     viewer.setStyle(
+                        {"model": model},
                         {
                             self.style: {
                                 "colorscheme": self.colorscheme,
                                 "radius": self.radius,
                             }
-                        }
+                        },
                     )
 
         return viewer
 
     @pyrosetta.distributed.requires_init
-    def apply_nglview(self, viewer, pose, pdbstring):
+    def apply_nglview(self, viewer, pose, pdbstring, model):
         # raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
         if self.command:
             pass
@@ -772,7 +777,7 @@ class setSurface(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring):
+    def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         py3Dmol = sys.modules["py3Dmol"]
         surface_types_dict: Dict[str, int] = {
             "VDW": py3Dmol.VDW,
@@ -792,24 +797,24 @@ class setSurface(ModuleBase):
                 viewer.addSurface(
                     surface_types_dict[self.surface_type],
                     {"opacity": self.opacity, "colorscheme": self.colorscheme},
-                    {"resi": resi, "chain": chain},
+                    {"model": model, "resi": resi, "chain": chain},
                 )
             elif self.color:
                 viewer.addSurface(
                     surface_types_dict[self.surface_type],
                     {"opacity": self.opacity, "color": self.color},
-                    {"resi": resi, "chain": chain},
+                    {"model": model, "resi": resi, "chain": chain},
                 )
             else:
                 viewer.addSurface(
                     surface_types_dict[self.surface_type],
                     {"opacity": self.opacity},
-                    {"resi": resi, "chain": chain},
+                    {"model": model, "resi": resi, "chain": chain},
                 )
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring):
+    def apply_nglview(self, viewer, pose, pdbstring, model):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -841,11 +846,11 @@ class setZoom(ModuleBase):
         validator=attr.validators.instance_of((float, int)),
     )
 
-    def apply_py3Dmol(self, viewer, pose, pdbstring):
+    def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         viewer.zoom(self.factor)
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring):
+    def apply_nglview(self, viewer, pose, pdbstring, model):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):
@@ -878,7 +883,7 @@ class setZoomTo(ModuleBase):
     )
 
     @pyrosetta.distributed.requires_init
-    def apply_py3Dmol(self, viewer, pose, pdbstring):
+    def apply_py3Dmol(self, viewer, pose, pdbstring, model):
         if pose is None:
             pose = _pdbstring_to_pose(pdbstring, self.__class__.__name__)
 
@@ -887,11 +892,11 @@ class setZoomTo(ModuleBase):
         if (not resi) and (not chain):
             pass
         else:
-            viewer.zoomTo({"resi": resi, "chain": chain})
+            viewer.zoomTo({"model": model}, {"resi": resi, "chain": chain})
 
         return viewer
 
-    def apply_nglview(self, viewer, pose, pdbstring):
+    def apply_nglview(self, viewer, pose, pdbstring, model):
         raise ModuleNotImplementedError(self.__class__.name__, BACKENDS[1])
 
     def apply_pymol(self):

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -773,7 +773,7 @@ class setStyle(ModuleBase):
         # Set defaults
         if self.cartoon_color is None:
             self.cartoon_color = "atomindex"
-        if self.colorscheme.endswith("Carbon"):
+        if isinstance(self.colorscheme, str) and self.colorscheme.endswith("Carbon"):
             if self.colorscheme == "blackCarbon":
                 self.colorscheme = "element"
             else:

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -553,7 +553,6 @@ class setStyle(ModuleBase):
                 else:
                     if self.cartoon:
                         viewer.setStyle(
-                            # {"model": model},
                             {"model": model, "resi": resi, "chain": chain},
                             {
                                 "cartoon": {"color": self.cartoon_color},
@@ -565,7 +564,6 @@ class setStyle(ModuleBase):
                         )
                     else:
                         viewer.setStyle(
-                            # {"model": model},
                             {"model": model, "resi": resi, "chain": chain},
                             {
                                 self.style: {
@@ -576,7 +574,6 @@ class setStyle(ModuleBase):
                         )
                     if self.label:
                         viewer.addResLabels(
-                            # {"model": model},
                             {"model": model, "resi": resi, "chain": chain},
                             {
                                 "fontSize": self.label_fontsize,

--- a/viewer3d/modules.py
+++ b/viewer3d/modules.py
@@ -172,25 +172,6 @@ class setDisulfides(ModuleBase):
             label_visible=False,
         )
 
-        #             r = res_hbonds[j]
-        #             don_res = r.don_res()
-        #             don_hatm_name = (
-        #                 pose.residue(don_res).atom_name(r.don_hatm()).strip()
-        #             )
-        #             don_residue, don_chain = _get_residue_chain_tuple(pose, don_res)
-        #             don_sele = f"{don_residue}:{don_chain}.{don_hatm_name}"
-        #             acc_res = r.acc_res()
-        #             acc_atm_name = pose.residue(acc_res).atom_name(r.acc_atm()).strip()
-        #             acc_residue, acc_chain = _get_residue_chain_tuple(pose, acc_res)
-        #             acc_sele = f"{acc_residue}:{acc_chain}.{acc_atm_name}"
-        #             selection_hbonds.append([don_sele, acc_sele])
-        #
-        # viewer.add_distance(
-        #     atom_pair=selection_hbonds,
-        #     color=self.color,
-        #     label_visible=False,
-        # )
-
         return viewer
 
     def apply_pymol(self):

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -23,6 +23,7 @@ from pyrosetta.rosetta.core.select.residue_selector import (
     LayerSelector,
     ResiduePropertySelector,
 )
+from viewer3d.converters import _to_backend
 from viewer3d.tracer import requires_init
 
 
@@ -55,6 +56,7 @@ def coreBoundarySurface(
         surface_selector.set_layers(False, False, True)
         surface_selector.set_use_sc_neighbors(True)
 
+    backend = _to_backend(backend)
     modules = [
         viewer3d.setStyle(
             cartoon=True,
@@ -272,6 +274,7 @@ def makeBundle(
     )
     from pyrosetta.rosetta.utility import vector1_unsigned_long
 
+    backend = _to_backend(backend)
     if not modules:
         with out:
             core_selector = LayerSelector()
@@ -283,8 +286,7 @@ def makeBundle(
         modules = [
             viewer3d.setStyle(
                 residue_selector=core_selector,
-                cartoon=False,
-                # cartoon_color="spectrum",
+                cartoon=False if backend == "nglview" else True,
                 colorscheme="darkred" if backend == "nglview" else "darkredCarbon",
                 style="stick",
                 radius=0.25,
@@ -292,8 +294,7 @@ def makeBundle(
             ),
             viewer3d.setStyle(
                 residue_selector=boundary_selector,
-                cartoon=False,
-                # cartoon_color="spectrum",
+                cartoon=False if backend == "nglview" else True,
                 colorscheme="orange" if backend == "nglview" else "orangeCarbon",
                 style="stick",
                 radius=0.25,
@@ -301,27 +302,21 @@ def makeBundle(
             ),
             viewer3d.setStyle(
                 residue_selector=surface_selector,
-                cartoon=False,
-                # cartoon_color="spectrum",
+                cartoon=False if backend == "nglview" else True,
                 colorscheme="yellow" if backend == "nglview" else "yellowCarbon",
                 style="stick",
                 radius=0.25,
                 label=False,
             ),
+        ]
+    if backend == "nglview":
+        modules.append(
             viewer3d.setStyle(
                 cartoon=True,
                 radius=0,
                 label=False,
-            ),
-        ]
-        # if backend == "nglview":
-        #     modules.append(
-        #         viewer3d.setStyle(
-        #             cartoon=True,
-        #             radius=0,
-        #             label=False,
-        #         ),
-        #     )
+            )
+        )
 
     pose = pyrosetta.Pose()
     view = viewer3d.init(

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -202,6 +202,7 @@ def makeBundle(
                 label=False,
             ),
             viewer3d.setHydrogens(),
+            viewer3d.setHydrogenBonds(),
         ]
 
     pose = pyrosetta.Pose()

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -231,7 +231,7 @@ def makeBundle(
         mb.apply(pose)
         add_pdb_info_mover.apply(pose)
         make_poly_X(pose)
-        view.update_viewer(pose)
+        view.update_pose(pose)
 
     def initialize_bundle():
         for i in range(1, num_helices + 1):

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -20,7 +20,7 @@ out = Output()
 
 @out.capture()
 @requires_init
-def coreBoundarySurface(**kwargs):
+def coreBoundarySurface(*args, **kwargs):
     """
     Display core residues as 'blackCarbon' sticks, boundary residues as 'greyCarbon' sticks, and surface residues
     as 'whiteCarbon' sticks, with 'spectrum' cartoon representation, using the default arguments in
@@ -35,7 +35,7 @@ def coreBoundarySurface(**kwargs):
     surface_selector = LayerSelector()
     surface_selector.set_layers(False, False, True)
 
-    view = viewer3d.init(**kwargs)
+    view = viewer3d.init(*args, **kwargs)
     view.add(viewer3d.setStyle())
     view.add(
         viewer3d.setStyle(
@@ -71,7 +71,7 @@ def coreBoundarySurface(**kwargs):
 
 @out.capture()
 @requires_init
-def ligandsAndMetals(**kwargs):
+def ligandsAndMetals(*args, **kwargs):
     """
     Display residues with `ResidueProperty.LIGAND` as 'brownCarbon' sticks with opaque surface,
     and `ResidueProperty.METAL` as 'chainHetatm' spheres, with 'spectrum' cartoon representation,
@@ -83,7 +83,7 @@ def ligandsAndMetals(**kwargs):
     ligands_selector = ResiduePropertySelector(ResidueProperty.LIGAND)
 
     view = (
-        viewer3d.init(**kwargs)
+        viewer3d.init(*args, **kwargs)
         + viewer3d.setStyle(style="stick", colorscheme="lightgreyCarbon", radius=0.15)
         + viewer3d.setStyle(
             residue_selector=ligands_selector,
@@ -116,11 +116,11 @@ def ligandsAndMetals(**kwargs):
 
 @out.capture()
 @requires_init
-def templatePreset(**kwargs):
+def templatePreset(*args, **kwargs):
     """
     Add a description of the preset Viewer here
     """
-    view = viewer3d.init(**kwargs)
+    view = viewer3d.init(*args, **kwargs)
 
     # Add custom Viewer commands here
 

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -201,6 +201,7 @@ def makeBundle(
                 radius=0,
                 label=False,
             ),
+            viewer3d.setHydrogens(),
         ]
 
     pose = pyrosetta.Pose()

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -130,6 +130,22 @@ def coreBoundarySurface(
         description="dist_midpoint",
         continuous_update=continuous_update,
     )
+    core_cutoff = FloatSlider(
+        min=0,
+        max=10,
+        step=0.1,
+        value=5.2,
+        description="core_cutoff",
+        continuous_update=continuous_update,
+    )
+    surface_cutoff = FloatSlider(
+        min=0,
+        max=10,
+        step=0.1,
+        value=2,
+        description="surface_cutoff",
+        continuous_update=continuous_update,
+    )
 
     view = viewer3d.init(
         packed_and_poses_and_pdbs=packed_and_poses_and_pdbs,
@@ -173,14 +189,46 @@ def coreBoundarySurface(
             surface_selector.set_sc_neighbor_dist_midpoint(dist_midpoint.new)
         view.update_viewer()
 
+    def set_core_cutoff(core_cutoff):
+        with out:
+            core_selector.set_cutoffs(core=core_cutoff.new, surf=surface_cutoff.value)
+            boundary_selector.set_cutoffs(
+                core=core_cutoff.new, surf=surface_cutoff.value
+            )
+            surface_selector.set_cutoffs(
+                core=core_cutoff.new, surf=surface_cutoff.value
+            )
+        view.update_viewer()
+
+    def set_surface_cutoff(surface_cutoff):
+        with out:
+            core_selector.set_cutoffs(core=core_cutoff.value, surf=surface_cutoff.new)
+            boundary_selector.set_cutoffs(
+                core=core_cutoff.value, surf=surface_cutoff.new
+            )
+            surface_selector.set_cutoffs(
+                core=core_cutoff.value, surf=surface_cutoff.new
+            )
+        view.update_viewer()
+
     angle_exponent.observe(set_angle_exponent, names="value")
     angle_shift_factor.observe(set_angle_shift_factor, names="value")
     dist_exponent.observe(set_dist_exponent, names="value")
     denominator.observe(set_sc_neighbor_denominator, names="value")
     dist_midpoint.observe(set_sc_neighbor_dist_midpoint, names="value")
+    core_cutoff.observe(set_core_cutoff, names="value")
+    surface_cutoff.observe(set_surface_cutoff, names="value")
 
     view.set_widgets(
-        [angle_exponent, angle_shift_factor, dist_exponent, denominator, dist_midpoint]
+        [
+            angle_exponent,
+            angle_shift_factor,
+            dist_exponent,
+            denominator,
+            dist_midpoint,
+            core_cutoff,
+            surface_cutoff,
+        ]
     )
     view.update_viewer()
 

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -18,7 +18,6 @@ _logger = logging.getLogger("viewer3d.presets")
 out = Output()
 
 
-@out.capture()
 @requires_init
 def coreBoundarySurface(*args, **kwargs):
     """
@@ -28,12 +27,13 @@ def coreBoundarySurface(*args, **kwargs):
     """
     __author__ = "Jason C. Klima"
 
-    core_selector = LayerSelector()
-    core_selector.set_layers(True, False, False)
-    boundary_selector = LayerSelector()
-    boundary_selector.set_layers(False, True, False)
-    surface_selector = LayerSelector()
-    surface_selector.set_layers(False, False, True)
+    with out:
+        core_selector = LayerSelector()
+        core_selector.set_layers(True, False, False)
+        boundary_selector = LayerSelector()
+        boundary_selector.set_layers(False, True, False)
+        surface_selector = LayerSelector()
+        surface_selector.set_layers(False, False, True)
 
     view = viewer3d.init(*args, **kwargs)
     view.add(viewer3d.setStyle())
@@ -69,7 +69,6 @@ def coreBoundarySurface(*args, **kwargs):
     return view
 
 
-@out.capture()
 @requires_init
 def ligandsAndMetals(*args, **kwargs):
     """
@@ -79,8 +78,9 @@ def ligandsAndMetals(*args, **kwargs):
     """
     __author__ = "Jason C. Klima"
 
-    metals_selector = ResiduePropertySelector(ResidueProperty.METAL)
-    ligands_selector = ResiduePropertySelector(ResidueProperty.LIGAND)
+    with out:
+        metals_selector = ResiduePropertySelector(ResidueProperty.METAL)
+        ligands_selector = ResiduePropertySelector(ResidueProperty.LIGAND)
 
     view = (
         viewer3d.init(*args, **kwargs)
@@ -114,7 +114,6 @@ def ligandsAndMetals(*args, **kwargs):
     return view
 
 
-@out.capture()
 @requires_init
 def templatePreset(*args, **kwargs):
     """
@@ -127,7 +126,6 @@ def templatePreset(*args, **kwargs):
     return view
 
 
-@out.capture()
 @requires_init
 def makeBundle(
     modules=[],
@@ -169,12 +167,13 @@ def makeBundle(
     from pyrosetta.rosetta.utility import vector1_unsigned_long
 
     if not modules:
-        core_selector = LayerSelector()
-        core_selector.set_layers(True, False, False)
-        boundary_selector = LayerSelector()
-        boundary_selector.set_layers(False, True, False)
-        surface_selector = LayerSelector()
-        surface_selector.set_layers(False, False, True)
+        with out:
+            core_selector = LayerSelector()
+            core_selector.set_layers(True, False, False)
+            boundary_selector = LayerSelector()
+            boundary_selector.set_layers(False, True, False)
+            surface_selector = LayerSelector()
+            surface_selector.set_layers(False, False, True)
         modules = [
             viewer3d.setStyle(
                 residue_selector=core_selector,

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -283,8 +283,8 @@ def makeBundle(
         modules = [
             viewer3d.setStyle(
                 residue_selector=core_selector,
-                cartoon=True,
-                cartoon_color="spectrum",
+                cartoon=False,
+                # cartoon_color="spectrum",
                 colorscheme="darkred" if backend == "nglview" else "darkredCarbon",
                 style="stick",
                 radius=0.25,
@@ -292,8 +292,8 @@ def makeBundle(
             ),
             viewer3d.setStyle(
                 residue_selector=boundary_selector,
-                cartoon=True,
-                cartoon_color="spectrum",
+                cartoon=False,
+                # cartoon_color="spectrum",
                 colorscheme="orange" if backend == "nglview" else "orangeCarbon",
                 style="stick",
                 radius=0.25,
@@ -301,22 +301,27 @@ def makeBundle(
             ),
             viewer3d.setStyle(
                 residue_selector=surface_selector,
-                cartoon=True,
-                cartoon_color="spectrum",
+                cartoon=False,
+                # cartoon_color="spectrum",
                 colorscheme="yellow" if backend == "nglview" else "yellowCarbon",
                 style="stick",
                 radius=0.25,
                 label=False,
             ),
+            viewer3d.setStyle(
+                cartoon=True,
+                radius=0,
+                label=False,
+            ),
         ]
-        if backend == "nglview":
-            modules.append(
-                viewer3d.setStyle(
-                    cartoon=True,
-                    radius=0,
-                    label=False,
-                ),
-            )
+        # if backend == "nglview":
+        #     modules.append(
+        #         viewer3d.setStyle(
+        #             cartoon=True,
+        #             radius=0,
+        #             label=False,
+        #         ),
+        #     )
 
     pose = pyrosetta.Pose()
     view = viewer3d.init(

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -283,34 +283,40 @@ def makeBundle(
         modules = [
             viewer3d.setStyle(
                 residue_selector=core_selector,
-                cartoon=False,
-                colorscheme="darkred",
+                cartoon=True,
+                cartoon_color="spectrum",
+                colorscheme="darkred" if backend == "nglview" else "darkredCarbon",
                 style="stick",
                 radius=0.25,
                 label=False,
             ),
             viewer3d.setStyle(
                 residue_selector=boundary_selector,
-                cartoon=False,
-                colorscheme="orange",
+                cartoon=True,
+                cartoon_color="spectrum",
+                colorscheme="orange" if backend == "nglview" else "orangeCarbon",
                 style="stick",
                 radius=0.25,
                 label=False,
             ),
             viewer3d.setStyle(
                 residue_selector=surface_selector,
-                cartoon=False,
-                colorscheme="yellow",
+                cartoon=True,
+                cartoon_color="spectrum",
+                colorscheme="yellow" if backend == "nglview" else "yellowCarbon",
                 style="stick",
                 radius=0.25,
                 label=False,
             ),
-            viewer3d.setStyle(
-                cartoon=True,
-                radius=0,
-                label=False,
-            ),
         ]
+        if backend == "nglview":
+            modules.append(
+                viewer3d.setStyle(
+                    cartoon=True,
+                    radius=0,
+                    label=False,
+                ),
+            )
 
     pose = pyrosetta.Pose()
     view = viewer3d.init(

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -164,7 +164,7 @@ def makeBundle(
     )
     from pyrosetta.rosetta.utility import vector1_unsigned_long
 
-    if not modules and (backend == "py3Dmol"):
+    if not modules:  # and (backend == "py3Dmol"):
         core_selector = LayerSelector()
         core_selector.set_layers(True, False, False)
         boundary_selector = LayerSelector()
@@ -174,29 +174,31 @@ def makeBundle(
         modules = [
             viewer3d.setStyle(
                 residue_selector=core_selector,
-                cartoon=True,
-                cartoon_color="red",
-                colorscheme="redCarbon",
+                cartoon=False,
+                colorscheme="red",
                 style="stick",
                 radius=0.25,
                 label=False,
             ),
             viewer3d.setStyle(
                 residue_selector=boundary_selector,
-                cartoon=True,
-                cartoon_color="orange",
-                colorscheme="orangeCarbon",
+                cartoon=False,
+                colorscheme="orange",
                 style="stick",
                 radius=0.25,
                 label=False,
             ),
             viewer3d.setStyle(
                 residue_selector=surface_selector,
-                cartoon=True,
-                cartoon_color="yellow",
-                colorscheme="yellowCarbon",
+                cartoon=False,
+                colorscheme="yellow",
                 style="stick",
                 radius=0.25,
+                label=False,
+            ),
+            viewer3d.setStyle(
+                cartoon=True,
+                radius=0,
                 label=False,
             ),
         ]

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -478,13 +478,13 @@ def makeBundle(
     invert.observe(on_invert_change, names="value")
 
     save_button = Button(description="save PDB")
-    save_edit = Text(value="bundle.pdb")
+    save_edit = Text(value="bundle.pdb", description="filename")
 
     def save_pdb(sender):
         pose.dump_pdb(save_edit.value)
 
     save_button.on_click(save_pdb)
-    save_box = HBox([save_button, save_edit])
+    save_box = HBox([save_button, save_edit], description="save_box")
 
     view.set_widgets(
         [

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -66,7 +66,7 @@ def coreBoundarySurface(
         viewer3d.setStyle(
             residue_selector=core_selector,
             cartoon=False,
-            colorscheme="darkred" if backend == "nglview" else "darkredCarbon",
+            colorscheme=0xF57900,
             style="stick",
             radius=0.25,
             label=False,
@@ -74,7 +74,7 @@ def coreBoundarySurface(
         viewer3d.setStyle(
             residue_selector=boundary_selector,
             cartoon=False,
-            colorscheme="orange" if backend == "nglview" else "orangeCarbon",
+            colorscheme=0x00CC00,
             style="stick",
             radius=0.25,
             label=False,
@@ -82,7 +82,7 @@ def coreBoundarySurface(
         viewer3d.setStyle(
             residue_selector=surface_selector,
             cartoon=False,
-            colorscheme="yellow" if backend == "nglview" else "yellowCarbon",
+            colorscheme=0x729FCF,
             style="stick",
             radius=0.25,
             label=False,
@@ -284,7 +284,7 @@ def makeBundle(
             viewer3d.setStyle(
                 residue_selector=core_selector,
                 cartoon=False if backend == "nglview" else True,
-                colorscheme="darkred" if backend == "nglview" else "darkredCarbon",
+                colorscheme=0xF57900,
                 style="stick",
                 radius=0.25,
                 label=False,
@@ -292,7 +292,7 @@ def makeBundle(
             viewer3d.setStyle(
                 residue_selector=boundary_selector,
                 cartoon=False if backend == "nglview" else True,
-                colorscheme="orange" if backend == "nglview" else "orangeCarbon",
+                colorscheme=0x00CC00,
                 style="stick",
                 radius=0.25,
                 label=False,
@@ -300,7 +300,7 @@ def makeBundle(
             viewer3d.setStyle(
                 residue_selector=surface_selector,
                 cartoon=False if backend == "nglview" else True,
-                colorscheme="yellow" if backend == "nglview" else "yellowCarbon",
+                colorscheme=0x729FCF,
                 style="stick",
                 radius=0.25,
                 label=False,

--- a/viewer3d/presets.py
+++ b/viewer3d/presets.py
@@ -138,43 +138,40 @@ def coreBoundarySurface(
         backend=backend,
     )
 
-    def update_viewer():
-        view.update_decoy()
-
     def set_angle_exponent(angle_exponent):
         with out:
             core_selector.set_angle_exponent(angle_exponent.new)
             boundary_selector.set_angle_exponent(angle_exponent.new)
             surface_selector.set_angle_exponent(angle_exponent.new)
-        update_viewer()
+        view.update_viewer()
 
     def set_angle_shift_factor(angle_shift_factor):
         with out:
             core_selector.set_angle_shift_factor(angle_shift_factor.new)
             boundary_selector.set_angle_shift_factor(angle_shift_factor.new)
             surface_selector.set_angle_shift_factor(angle_shift_factor.new)
-        update_viewer()
+        view.update_viewer()
 
     def set_dist_exponent(dist_exponent):
         with out:
             core_selector.set_dist_exponent(dist_exponent.new)
             boundary_selector.set_dist_exponent(dist_exponent.new)
             surface_selector.set_dist_exponent(dist_exponent.new)
-        update_viewer()
+        view.update_viewer()
 
     def set_sc_neighbor_denominator(denominator):
         with out:
             core_selector.set_sc_neighbor_denominator(denominator.new)
             boundary_selector.set_sc_neighbor_denominator(denominator.new)
             surface_selector.set_sc_neighbor_denominator(denominator.new)
-        update_viewer()
+        view.update_viewer()
 
     def set_sc_neighbor_dist_midpoint(dist_midpoint):
         with out:
             core_selector.set_sc_neighbor_dist_midpoint(dist_midpoint.new)
             boundary_selector.set_sc_neighbor_dist_midpoint(dist_midpoint.new)
             surface_selector.set_sc_neighbor_dist_midpoint(dist_midpoint.new)
-        update_viewer()
+        view.update_viewer()
 
     angle_exponent.observe(set_angle_exponent, names="value")
     angle_shift_factor.observe(set_angle_shift_factor, names="value")
@@ -185,7 +182,7 @@ def coreBoundarySurface(
     view.set_widgets(
         [angle_exponent, angle_shift_factor, dist_exponent, denominator, dist_midpoint]
     )
-    update_viewer()
+    view.update_viewer()
 
     return view
 

--- a/viewer3d/tests/test_viewer.py
+++ b/viewer3d/tests/test_viewer.py
@@ -1,3 +1,4 @@
+import itertools
 import glob
 import logging
 import os
@@ -51,10 +52,14 @@ class TestViewer(unittest.TestCase):
             + viewer3d.setStyle(style="line", colorscheme="blueCarbon")
         )
         view.show()
-        self.assertEqual(view.poses, [None] * len(pdbfiles))
+        self.assertEqual(
+            list(itertools.chain(*view.poses.values())), [None] * len(pdbfiles)
+        )
         self.assertEqual(len(view.modules), 2)
         view.reinit()
-        self.assertEqual(view.poses, [None] * len(pdbfiles))
+        self.assertEqual(
+            list(itertools.chain(*view.poses.values())), [None] * len(pdbfiles)
+        )
         self.assertEqual(len(view.modules), 0)
         view.reset()
         self.assertIsNone(view.poses)
@@ -76,10 +81,10 @@ class TestViewer(unittest.TestCase):
         ]
         view = sum([viewer3d.init(poses)] + modules)
         view()
-        self.assertEqual(view.poses, poses)
+        self.assertListEqual(list(itertools.chain(*view.poses.values())), poses)
         self.assertEqual(len(view.modules), 2)
         view.reinit()
-        self.assertEqual(view.poses, poses)
+        self.assertListEqual(list(itertools.chain(*view.poses.values())), poses)
         self.assertEqual(len(view.modules), 0)
         view.modules = modules
         self.assertEqual(len(view.modules), len(modules))

--- a/viewer3d/tracer.py
+++ b/viewer3d/tracer.py
@@ -1,0 +1,29 @@
+import pyrosetta
+import pyrosetta.distributed
+
+from functools import wraps
+from pyrosetta.rosetta.basic.options import get_integer_option, set_integer_option
+from typing import (
+    Any,
+    Callable,
+    TypeVar,
+    cast,
+)
+
+
+T = TypeVar("T", bound=Callable[..., Any])
+
+
+@pyrosetta.distributed.requires_init
+def silence_tracer(func: T) -> T:
+    """Silence PyRosetta tracer output."""
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        option = "out:level"
+        user_out_level = get_integer_option(option)
+        set_integer_option(option, 100)
+        func(self, *args, **kwargs)
+        set_integer_option(option, user_out_level)
+
+    return cast(T, wrapper)


### PR DESCRIPTION
The goal of this PR is to address:

- #10
- #9 
- #8 
- Add a preset exposing `LayerSelector` methods as widgets, for dynamic layer selector coloring upon parameter changes.
- Refactor `core.py` and `base.py` to allow for overlaying multiple poses using the `view.add_pose(pose, index=0)` method. Also available are the `view.update_pose` and `view.remove_pose` methods (and corresponding methods with PDB strings). Poses were previously appended to the `view.poses` instance attribute which was of type `list`, but the `view.poses` instance attribute is now refactored into a dictionary with `int`-type keys specifying the `index` to be displayed and `list`-type values containing `Pose` objects to be overlaid in the display. This refactor leverages the multiple model support of `py3Dmol` and `nglview`.
- Set PDB strings to `None` if `Pose` objects are input parameters - previously the Viewer was converting `Pose` objects to PDB `str` objects anyway and shuttling them around. The Viewer feels faster to display `Pose` objects after this change.
- Support `nglview` with all of the existing modules.
- Update the `makeBundle` preset logging and coloring (i.e. `darkred` for the core layer because `red` made oxygen atoms indistinguishable).
- Automatically run the `setZoomTo` module to orient the pose before `view.show()` is called (otherwise the protein can end up outside the field of view, depending on the 3D coordinates).